### PR TITLE
Fix python 2.4 issues with tarfile

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog for zest.releaser
 3.31 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix python 2.4 issues with tarfile [kiorky]
 
 
 3.30 (2011-12-27)

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -105,10 +105,9 @@ class Releaser(baserelease.Basereleaser):
 
     def _sdist_options(self):
         options = []
-        if self._is_python24():
-            # Due to a bug in python24, tar files might get corrupted.
-            # We circumvent that by forcing zip files
-            options.append('--formats=zip')
+        # Due to a bug in python24, tar files might get corrupted on READ.
+        # We circumvent that by forcing zip files
+        options.append('--formats=zip')
         return " ".join(options)
 
     def _upload_distributions(self, package, sdist_options, pypiconfig):


### PR DESCRIPTION
The bug in python2.4 is not only at upload time but also when users will download the file.
We need so to always release the distribution as zip.
