### PR TITLE
Documentation Fix.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 See zest/releaser/README.txt.
 
-Bugs can be reported at https://bugs.launchpad.net/zest.releaser.
+Bugs can be reported at https://github.com/zestsoftware/zest.releaser/issues
 But with the move to github we also have an issue tracker there.  We
 may decide to shut down one of them (if possible), but for now both
 work.


### PR DESCRIPTION
This pull requests changes the bug reporting url from launchpad to github in 
the documentation.

Don't forget to do a new release because the wron url is also shown on pypi.
