### PR TITLE
Add the possibility to specify the history file location

### DIFF
--- a/zest/releaser/prerelease.py
+++ b/zest/releaser/prerelease.py
@@ -94,7 +94,11 @@ class Prereleaser(baserelease.Basereleaser):
         check if the first one matches the version and whether it has a the
         current date.
         """
-        history_file = self.vcs.history_file()
+        default_location = None
+        if self.setup_cfg.config.has_option('zest.releaser', 'history_file'):
+            default_location = self.setup_cfg.config.get('zest.releaser',
+                                                         'history_file')
+        history_file = self.vcs.history_file(location=default_location)
         if not history_file:
             logger.warn("No history file found")
             self.data['history_lines'] = None

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -94,9 +94,15 @@ class BaseVersionControl(object):
                         "change: %s", ', '.join(found))
         return found[0]
 
-    def history_file(self):
+    def history_file(self, location=None):
         """Return history file location.
         """
+        if location:
+            if os.path.exists(location) is False:
+                logger.warn("The specified history file %s doesn't exist",
+                            location)
+            else:
+                return location
         filenames = []
         for base in ['CHANGES', 'HISTORY', 'CHANGELOG']:
             filenames.append(base)


### PR DESCRIPTION
This commit add the possibility to specify the location of the history file into the zest.releaser section of the setup.cfg file. If the specified file doesn't exist a warning is printed and the search of the history file is performed.

This pull request fixes #25
