### PR TITLE
Support git clones that are not directly in the root.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog for zest.releaser
 3.43 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Allow use of Git repository containing multiple directory, implicitely,
+  subdirectories must contain a setup.py and a CHANGES.txt to be released.
 
 
 3.42 (2013-01-07)

--- a/zest/releaser/choose.py
+++ b/zest/releaser/choose.py
@@ -31,7 +31,7 @@ def version_control():
         # .git tree. If we are not in a git repository, the answer will looks
         # like 'Not a git repository' or even 'git: not found'
         last_try = utils.system("git  rev-parse --is-inside-work-tree")
-        if last_try in ['true\n', 'false\n']:
+        if last_try == 'true\n':
             return git.Git()
         logger.critical('No version control system detected.')
         sys.exit(1)


### PR DESCRIPTION
In the spirit of the commit 0d3be48 for SVN 1.7+ checkouts, this commit
allow to release from a subdirectory of a git repository.
Credits to http://stackoverflow.com/questions/2044574/determine-if-directory-is-under-git-control for the detection method.
