### PR TITLE
Use `nextversion` for generating next version string.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name='zest.releaser',
       install_requires=[
           'setuptools',
           # -*- Extra requirements: -*-
+          'nextversion',
       ],
       extras_require={
           'test': ['z3c.testsetup']},

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import sys
+from nextversion import nextversion
 
 from zest.releaser import baserelease
 from zest.releaser import utils
@@ -64,24 +65,7 @@ class Postreleaser(baserelease.Basereleaser):
         current = self.vcs.version
         # Clean it up to a non-development version.
         current = utils.cleanup_version(current)
-        # Try to make sure that the suggestion for next version after
-        # 1.1.19 is not 1.1.110, but 1.1.20.
-        current_split = current.split('.')
-        major = '.'.join(current_split[:-1])
-        minor = current_split[-1]
-        try:
-            minor = int(minor) + 1
-            suggestion = '.'.join([major, str(minor)])
-        except ValueError:
-            # Fall back on simply updating the last character when it is
-            # an integer.
-            try:
-                last = int(current[-1]) + 1
-                suggestion = current[:-1] + str(last)
-            except ValueError:
-                logger.warn("Version does not end with a number, so we can't "
-                            "calculate a suggestion for a next version.")
-                suggestion = None
+        suggestion = nextversion(current)
         print "Current version is %r" % current
         q = "Enter new development version ('.dev0' will be appended)"
         version = utils.ask_version(q, default=suggestion)

--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -75,14 +75,13 @@ is not recognized as development version:
     >>> vcs.version
     '0.1b'
 
-Run the postrelease script.  Since the version number does not end
-with a number, the script cannot make a suggestion:
+Run the postrelease script:
 
     >>> utils.answers_for_testing = ['0.2', '']
     >>> from zest.releaser import postrelease
     >>> postrelease.main()
     Current version is '0.1b'
-    Question: Enter new development version ('.dev0' will be appended):
+    Question: Enter new development version ('.dev0' will be appended) [0.1b1]:
     Our reply: 0.2
     Checking data dict
     Question: OK to commit this (Y/n)?
@@ -133,14 +132,10 @@ cannot suggest a reasonable number. We'll ask for a version until we get one:
     Checking data dict
     Question: OK to commit this (Y/n)?
     Our reply: <ENTER>
-    >>> utils.answers_for_testing = ['', '', '0.3rc', '']
+    >>> utils.answers_for_testing = ['0.3rc', '']
     >>> postrelease.main()
     Current version is '0.3beta'
-    Question: Enter new development version ('.dev0' will be appended):
-    Our reply: <ENTER>
-    Question: Enter new development version ('.dev0' will be appended):
-    Our reply: <ENTER>
-    Question: Enter new development version ('.dev0' will be appended):
+    Question: Enter new development version ('.dev0' will be appended) [0.3b1]:
     Our reply: 0.3rc
     Checking data dict
     Question: OK to commit this (Y/n)?


### PR DESCRIPTION
Version string has a rule (PEP 386). It should be followed when suggesting new
version string.
`nextversion` module (https://pypi.python.org/pypi/nextversion) generates PEP
386 compatible version string, so it seems to be good idea to use it.
