### PR TITLE
Changed command "hg manifest" to "hg locate" to list files in Mercurial.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 3.50 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Changed command "hg manifest" to "hg locate" to list files in Mercurial.
+  The former prints out file permissions along with the file name, causing a bug.
+  [rafaelbco]
 
 
 3.49 (2013-12-06)

--- a/zest/releaser/hg.py
+++ b/zest/releaser/hg.py
@@ -95,4 +95,4 @@ class Hg(BaseVersionControl):
 
     def list_files(self):
         """List files in version control."""
-        return system('hg manifest').splitlines()
+        return system('hg locate').splitlines()


### PR DESCRIPTION
The former prints out file permissions along with the file name, causing a bug.
