### PR TITLE
When calling 'python setup.py' use the same PYTHONPATH as the script.

### DIFF
--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -349,19 +349,10 @@ Safe setup.py running
 ---------------------
 
 ``setup_py()`` returns the ``python setup.py xyz`` command line by using
-sys.executable.  We prepend this with ``PYTHONPATH`` on posix-like
-platforms, which is better in corner cases.
+sys.executable.
 
     >>> cmd = utils.setup_py('cook a cow')
-    >>> cmd = cmd.replace(sys.executable, 'python') # test normalization
-    >>> import os
-    >>> if os.name == 'posix':
-    ...     pythonpath = 'PYTHONPATH=%s ' % os.pathsep.join(sys.path)
-    ... else:
-    ...     pythonpath = ''
-    >>> cmd.startswith(pythonpath)
-    True
-    >>> print cmd[len(pythonpath):]
+    >>> print cmd.replace(sys.executable, 'python') # test normalization
     python setup.py cook a cow
 
 When the setup.py arguments include arguments that indicate pypi interaction,

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -242,14 +242,6 @@ def show_last_lines(result):
 def setup_py(rest_of_cmdline):
     """Return 'python setup.py' command (with hack for testing)"""
     executable = sys.executable
-    if os.name == 'posix':
-        # Set PYTHONPATH explicitly to be the same as for
-        # zest.releaser.  This helps for cases where the standard
-        # python for example does not have setuptools installed.  But
-        # this does not work on Windows and maybe other platforms.
-        executable = 'PYTHONPATH=%s %s' % (
-            os.pathsep.join(sys.path), sys.executable)
-
     if TESTMODE:
         # Hack for testing
         for unsafe in ['upload', 'register', 'mregister']:


### PR DESCRIPTION
See issue #24.
