### PR TITLE
Issue70 unwriteable version halt

### DIFF
--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -225,6 +225,8 @@ class BaseVersionControl(object):
                 logger.info("Set setup.py's version to %r", version)
                 return
 
+        raise Exception("Failed to locate assignment of version number for update.")
+
     version = property(_extract_version, _update_version)
 
     #

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -210,7 +210,7 @@ class BaseVersionControl(object):
         good_version = "version = '%s'" % version
         line_number = 0
         setup_lines = open('setup.py').read().split('\n')
-        for line in setup_lines:
+        for line_number, line in enumerate(setup_lines):
             match = VERSION_PATTERN.search(line)
             if match:
                 logger.debug("Matching version line found: %r", line)
@@ -220,11 +220,10 @@ class BaseVersionControl(object):
                     # Note: no spaces around the '='.
                     good_version = indentation + "version='%s'," % version
                 setup_lines[line_number] = good_version
-                break
-            line_number += 1
-        contents = '\n'.join(setup_lines)
-        open('setup.py', 'w').write(contents)
-        logger.info("Set setup.py's version to %r", version)
+                contents = '\n'.join(setup_lines)
+                open('setup.py', 'w').write(contents)
+                logger.info("Set setup.py's version to %r", version)
+                return
 
     version = property(_extract_version, _update_version)
 


### PR DESCRIPTION
Fix for issue https://github.com/zestsoftware/zest.releaser/issues/70

As the docstring mentions, [`vcs.py:BaseVersionControl._update_version`](https://github.com/zestsoftware/zest.releaser/blob/master/zest/releaser/vcs.py#L175-229) looks in 3 places for a version number. The first 2 chunks of code look for the version number, and if found, make their change and return. I've refactored the 3rd chunk to match this pattern. This has the advantage of no longer re-writing setup.py when there are no changes, and no longer logging a message reporting success, regardless of outcome.

Instead we return if version is found, otherwise raise an Exception. Let me know if there's a particular exception class I should use instead of `Exception`.

Feedback welcome.