### PR TITLE
Fix for #72 - WindowsError while getting version

### DIFF
--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -432,7 +432,7 @@ def system(command, input=''):
     """commands.getoutput() replacement that also works on windows"""
     # print "CMD: %r" % command
     if command.startswith(sys.executable):
-        env = {'PYTHONPATH': os.pathsep.join(sys.path)}
+        env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
     else:
         env = None
     p = subprocess.Popen(command,


### PR DESCRIPTION
`utils.system` - Replacing the entire environment causes Windows Side-by-side to freak out since %SYSTEMROOT% is missing, so preserve (and update) the environment when calling subprocesses.

See #72 for more details.