### PR TITLE
Add optional support for uploading Python wheels.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ Changelog for zest.releaser
 3.57 (unreleased)
 -----------------
 
+- Add optional support for uploading Python wheels.  Use the new
+  ``zest.releaser[recommended]`` extra, or pip install ``wheel``
+  yourself next to ``zest.releaser``.  Create or edit ``setup.cfg`` in
+  your project (or globally in your ``~/.pypirc``) and create a section
+  ``[zest.releaser]`` with ``create_wheel = yes`` to create a wheel to
+  upload to PyPI.
+  Issue #55
+  [maurits]
+
 - Fix a random test failure on Travis CI, by resetting
   ``AUTO_RESPONSE``.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog for zest.releaser
 -----------------
 
 - Add optional support for uploading Python wheels.  Use the new
-  ``zest.releaser[recommended]`` extra, or pip install ``wheel``
+  ``zest.releaser[recommended]`` extra, or run ``pip install wheel``
   yourself next to ``zest.releaser``.  Create or edit ``setup.cfg`` in
   your project (or globally in your ``~/.pypirc``) and create a section
   ``[zest.releaser]`` with ``create_wheel = yes`` to create a wheel to

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -18,6 +18,7 @@ docutils = 0.12
 martian = 0.14
 setuptools = 8.2
 six = 1.8.0
+wheel = 0.24.0
 z3c.testsetup = 0.8.3
 zc.buildout = 2.3.1
 zc.recipe.egg = 2.0.1
@@ -38,6 +39,7 @@ recipe = zc.recipe.testrunner
 defaults = ['--tests-pattern', '^tests$', '-v', '-c']
 eggs =
      zest.releaser
+     zest.releaser[recommended]
      zest.releaser[test]
 
 

--- a/doc/source/uploading.rst
+++ b/doc/source/uploading.rst
@@ -89,6 +89,19 @@ You can use no/false/off/0 or yes/true/on/1 as answers; upper, lower or mixed
 case are all fine.
 
 
+Uploading wheels
+----------------
+
+First, you should install the ``zest.releaser[recommended]`` extra, or
+``pip install wheel`` yourself next to ``zest.releaser``.  Then create
+or edit ``setup.cfg`` in your project (or globally in your
+``~/.pypirc``) and add this to create and upload a wheel to upload to
+PyPI::
+
+ [zest.releaser]
+  create_wheel = yes
+
+
 Including all files in your release
 -----------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[zest.releaser]
+create_wheel = yes

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(name='zest.releaser',
           # -*- Extra requirements: -*-
       ],
       extras_require={
+          'recommended': [
+              'wheel',
+              ],
           'test': ['z3c.testsetup']},
       entry_points={
           'console_scripts': [

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -1,10 +1,18 @@
 import logging
 import os
+import pkg_resources
 import sys
 
 from ConfigParser import ConfigParser
 from ConfigParser import NoSectionError
 from ConfigParser import NoOptionError
+
+try:
+    pkg_resources.get_distribution('wheel')
+except pkg_resources.DistributionNotFound:
+    USE_WHEEL = False
+else:
+    USE_WHEEL = True
 
 try:
     from collective.dist import mupload
@@ -257,6 +265,30 @@ class PypiConfig(object):
             return default
         try:
             result = self.config.getboolean('zest.releaser', 'release')
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
+
+    def create_wheel(self):
+        """Should we create a Python wheel for this package?
+
+        Either in your ~/.pypirc or in a setup.cfg in a specific
+        package, add this when you want to create a Python wheel, next
+        to a standard sdist:
+
+        [zest.releaser]
+        create_wheel = yes
+
+        """
+        if not USE_WHEEL:
+            # If the wheel package is not available, we obviously
+            # cannot create wheels.
+            return False
+        default = False
+        if self.config is None:
+            return default
+        try:
+            result = self.config.getboolean('zest.releaser', 'create_wheel')
         except (NoSectionError, NoOptionError, ValueError):
             return default
         return result

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -10,13 +10,6 @@ from zest.releaser import pypi
 from zest.releaser import utils
 from zest.releaser.utils import system
 
-try:
-    pkg_resources.get_distribution('wheel')
-except pkg_resources.DistributionNotFound:
-    USE_WHEEL = False
-else:
-    USE_WHEEL = True
-
 DATA = {
     # Documentation for self.data.  You get runtime warnings when something is
     # in self.data that is not in this list.  Embarrasment-driven
@@ -111,7 +104,7 @@ class Releaser(baserelease.Basereleaser):
         # See if creating an sdist (and maybe a wheel) actually works.
         # Also, this makes the sdist (and wheel) available for plugins.
         logger.info("Making an egg of a fresh tag checkout.")
-        if USE_WHEEL:
+        if pypiconfig.create_wheel():
             print system(utils.setup_py('sdist bdist_wheel'))
         else:
             print system(utils.setup_py('sdist'))
@@ -151,7 +144,7 @@ class Releaser(baserelease.Basereleaser):
         # other servers to upload to.
         for server in pypiconfig.distutils_servers():
             if pypi.new_distutils_available():
-                if USE_WHEEL:
+                if pypiconfig.create_wheel():
                     commands = ('register', '-r', server, 'sdist',
                                 'bdist_wheel',
                                 'upload', '-r', server)

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -221,7 +221,7 @@ release.  This means you can usually just press Enter on all questions
 that zest.releaser asks.
 
 We try to read a [zest.releaser] section, either in pypirc or
-setup.cfg.  Currently we only check for a 'release' option.  We can
+setup.cfg and look  for a ``release`` option.  We can
 ask for the result like this, which by default is True:
 
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_both)
@@ -242,6 +242,39 @@ We can also specify to always do that checkout during a release:
     ...     'zest.releaser.tests', 'pypirc_yes_release.txt')
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_yes_release)
     >>> pypiconfig.want_release()
+    True
+
+
+Creating a wheel
+----------------
+
+When the ``wheel`` package is installed, we could create shiny new
+Python wheels, next to the standard old-style source distributions.
+This seems good, but not for every package.  So you have to explicitly
+turn it on.
+
+We try to read a [zest.releaser] section, either in pypirc or
+setup.cfg and check for a ``create_wheel`` option.  We can
+ask for the result like this, which by default is False:
+
+    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_both)
+    >>> pypiconfig.create_wheel()
+    False
+
+We have a pypirc for this where we implicitly set it to False:
+
+    >>> pypirc_no_release = pkg_resources.resource_filename(
+    ...     'zest.releaser.tests', 'pypirc_no_release.txt')
+    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_no_release)
+    >>> pypiconfig.create_wheel()
+    False
+
+We can also specify to always create it:
+
+    >>> pypirc_yes_release = pkg_resources.resource_filename(
+    ...     'zest.releaser.tests', 'pypirc_yes_release.txt')
+    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_yes_release)
+    >>> pypiconfig.create_wheel()
     True
 
 

--- a/zest/releaser/tests/pypirc_yes_release.txt
+++ b/zest/releaser/tests/pypirc_yes_release.txt
@@ -8,3 +8,4 @@ password:password
 
 [zest.releaser]
 release = yes
+create_wheel = yes


### PR DESCRIPTION
Use the new zest.releaser[recommended] extra, or pip install
wheel yourself next to zest.releaser.

Issue #55