### PR TITLE
Remove code for support of collective.sdist.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog for zest.releaser
 3.57 (unreleased)
 -----------------
 
+- Remove code for support of collective.sdist.  That package was a
+  backport from distutils for Python 2.5 and earlier, which we do not
+  support.
+  [maurits]
+
 - Fix a random test failure on Travis CI, by resetting
   ``AUTO_RESPONSE``.
   [maurits]

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 
 from ConfigParser import ConfigParser
 from ConfigParser import NoSectionError

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -6,39 +6,10 @@ from ConfigParser import ConfigParser
 from ConfigParser import NoSectionError
 from ConfigParser import NoOptionError
 
-try:
-    from collective.dist import mupload
-    mupload  # pyflakes
-except ImportError:
-    mupload = None
-
 DIST_CONFIG_FILE = '.pypirc'
 SETUP_CONFIG_FILE = 'setup.cfg'
 
 logger = logging.getLogger(__name__)
-
-
-def collective_dist_available():
-    """Return whether collective.dist is available"""
-    if mupload is not None:
-        return True
-    return False
-
-
-def new_distutils_available():
-    """Return whether a recent enough python is available for multiple pypi"""
-    if sys.version_info[:2] >= (2, 6):
-        # 2.6 (or higher) does not need collective.dist: distutils includes
-        # the needed functionality.
-        return True
-    return False
-
-
-def multiple_pypi_support():
-    """Return whether we can upload to multiple pypi servers"""
-    if collective_dist_available() or new_distutils_available():
-        return True
-    return False
 
 
 class SetupConfig(object):
@@ -197,8 +168,6 @@ class PypiConfig(object):
         return True
 
     def is_new_pypi_config(self):
-        if not multiple_pypi_support():
-            return False
         try:
             self.config.get('distutils', 'index-servers')
         except (NoSectionError, NoOptionError):
@@ -206,13 +175,11 @@ class PypiConfig(object):
         return True
 
     def distutils_servers(self):
-        """Return a list of known distutils servers for collective.dist.
+        """Return a list of known distutils servers.
 
         If the config has an old pypi config, remove the default pypi
         server from the list.
         """
-        if not multiple_pypi_support():
-            return []
         try:
             raw_index_servers = self.config.get('distutils', 'index-servers')
         except (NoSectionError, NoOptionError):

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -111,8 +111,7 @@ class Releaser(baserelease.Basereleaser):
                         pypi.DIST_CONFIG_FILE)
             return
 
-        # First ask if we want to upload to pypi, which should always
-        # work, also without collective.dist.
+        # First ask if we want to upload to pypi.
         use_pypi = package_in_pypi(package)
         if use_pypi:
             logger.info("This package is registered on PyPI.")
@@ -136,21 +135,10 @@ class Releaser(baserelease.Basereleaser):
                 result = system(shell_command)
                 utils.show_first_and_last_lines(result)
 
-        # If collective.dist is installed (or we are using
-        # python2.6 or higher), the user may have defined
-        # other servers to upload to.
+        # The user may have defined other servers to upload to.
         for server in pypiconfig.distutils_servers():
-            if pypi.new_distutils_available():
-                commands = ('register', '-r', server, 'sdist',
-                            'upload', '-r', server)
-            else:
-                # This would be logical, given the lines above:
-                # commands = ('mregister', '-r', server, 'sdist',
-                #            'mupload', '-r', server)
-                # But according to the collective.dist documentation
-                # it should be this (with just one '-r'):
-                commands = ('mregister', 'sdist',
-                            'mupload', '-r', server)
+            commands = ('register', '-r', server, 'sdist',
+                        'upload', '-r', server)
             shell_command = utils.setup_py(' '.join(commands))
             default = True
             exact = False

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -135,7 +135,7 @@ class Releaser(baserelease.Basereleaser):
                 utils.show_first_and_last_lines(result)
 
         # The user may have defined other servers to upload to.
-        for server in pypiconfig.distutils_servers():
+        for server in self.pypiconfig.distutils_servers():
             commands = ('register', '-r', server, 'sdist',
                         'upload', '-r', server)
             shell_command = utils.setup_py(' '.join(commands))

--- a/zest/releaser/tests/functional-svn.txt
+++ b/zest/releaser/tests/functional-svn.txt
@@ -120,10 +120,7 @@ The release script tags the release and uploads it:
     Our reply: y
     MOCK setup.py register sdist upload...
 
-That last line might be something like "mregister sdist mupload -r
-pypi" but we catch that with the test normalizer.
-
-If collective.dist is installed, the last dots above could be saying
+Note that the last dots above could be saying
 that we upload to alternative pypis as well.
 
 There is now a tag:

--- a/zest/releaser/tests/functional.py
+++ b/zest/releaser/tests/functional.py
@@ -159,13 +159,3 @@ def teardown(test):
     # Reset constants to original settings:
     utils.AUTO_RESPONSE = False
     utils.TESTMODE = False
-
-
-def restore_mupload(test):
-    from zest.releaser import pypi
-
-    try:
-        from collective.dist import mupload
-    except ImportError:
-        mupload = None
-    pypi.mupload = mupload

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -2,7 +2,6 @@ Detailed tests of pypi.py
 ===========================
 
 .. :doctest:
-.. :teardown: zest.releaser.tests.functional.restore_mupload
 
 Note on test setup: we don't use the "big" setup/teardown methods here.
 
@@ -10,72 +9,11 @@ Note on test setup: we don't use the "big" setup/teardown methods here.
     >>> import pkg_resources
 
 
-Multiple pypi servers support detection
----------------------------------------
-
-The module attempts to import ``mupload`` from collective.dist and sets it to
-None otherwise.  We don't influence the setup on the machine where this test
-runs, so we can only check if it is available:
-
-    >>> dont_care = pypi.mupload
-
-If mupload is not None, collective.dist is available, otherwise not.
-
-    >>> pypi.mupload = 'something'
-    >>> pypi.collective_dist_available()
-    True
-    >>> pypi.mupload = None
-    >>> pypi.collective_dist_available()
-    False
-
-A check for python versions is also made.
-
-    >>> import sys
-    >>> orig_version = sys.version_info
-
-Python 2.6 and higher provide the needed functionality (in distutils;
-collective.dist just backports that to older python versions):
-
-    >>> sys.version_info = (2, 5)
-    >>> pypi.new_distutils_available()
-    False
-    >>> sys.version_info = (2, 6)
-    >>> pypi.new_distutils_available()
-    True
-    >>> sys.version_info = (3, 1)
-    >>> pypi.new_distutils_available()
-    True
-
-If any of these two is true, multiple pypi support is available.
-
-    >>> pypi.mupload = None
-    >>> sys.version_info = (2, 5)
-    >>> pypi.multiple_pypi_support()
-    False
-    >>> pypi.mupload = 'available'
-    >>> sys.version_info = (2, 5)
-    >>> pypi.multiple_pypi_support()
-    True
-    >>> pypi.mupload = None
-    >>> sys.version_info = (2, 6)
-    >>> pypi.multiple_pypi_support()
-    True
-    >>> pypi.mupload = 'available'
-    >>> sys.version_info = (2, 6)
-    >>> pypi.multiple_pypi_support()
-    True
-
-For the rest of the tests we assume that collective.dist is available:
-
-    >>> pypi.mupload = 'mock that collective.dist is available'
-
-
-
 Parsing the configuration file
 ------------------------------
 
-For pypi uploads and collective.dist-style uploads to multiple servers, a
-configuration file needs to be available:
+For pypi uploads and uploads to multiple servers, a configuration file
+needs to be available:
 
     >>> pypi.DIST_CONFIG_FILE
     '.pypirc'
@@ -167,36 +105,14 @@ A file with both is also possible:
     >>> pypiconfig.is_new_pypi_config()
     True
 
-If there's no multiple pypi support, a config file in the new format isn't
-recognized as the new format as it cannot possibly function:
-
-    >>> pypi.mupload = None
-    >>> sys.version_info = (2, 5)
-    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_new)
-    >>> pypiconfig.config is None # Config is always set.
-    False
-    >>> pypiconfig.is_old_pypi_config()
-    False
-    >>> pypiconfig.is_new_pypi_config()
-    False
-
-If there's no collective.dist, there's also no list of distutils servers:
-
-    >>> pypiconfig.distutils_servers()
-    []
-
-Reset the collective.dist again:
-
-    >>> pypi.mupload = 'mock that collective.dist is available'
-
-Now we can parse the new format again and query a list of distutils servers:
+Parse the new format again and query a list of distutils servers:
 
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_new)
     >>> from pprint import pprint
     >>> pprint(sorted(pypiconfig.distutils_servers()))
     ['mycompany', 'plone.org', 'pypi']
 
-If we have an old config file, the distutils server list is also empty:
+If we have an old config file, the distutils server list is empty:
 
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_old)
     >>> pypiconfig.distutils_servers()
@@ -324,10 +240,6 @@ We try that again with this fixed up config file as input:
     [egg_info]
     tag_build =
     tag_svn_revision = false
-
-We are done with testing so we restore the original version:
-
-    >>> sys.version_info = orig_version
 
 
 No-input mode

--- a/zest/releaser/tests/test_setup.py
+++ b/zest/releaser/tests/test_setup.py
@@ -35,10 +35,6 @@ checker = renormalizing.RENormalizing([
      'TESTTEMP'),
     (re.compile(re.escape(tempfile.gettempdir())),
      'TMPDIR'),
-    # 'register sdist upload' or
-    # 'mregister sdist  mupload -r pypi' are both fine:
-    (re.compile('mregister sdist mupload -r [alpha]*$'),
-     'register sdist upload'),
     # Python 2.7 prints 'Creating tar archive' instead of
     # 'tar -cf dist/tha.example-0.1.tar tha.example-0.1
     #  ...':

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -366,8 +366,6 @@ happens when TESTMODE is on:
     echo MOCK setup.py mupload
     >>> print utils.setup_py('register')
     echo MOCK setup.py register
-    >>> print utils.setup_py('mregister')
-    echo MOCK setup.py mregister
 
 
 Data dict documentation

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -260,7 +260,7 @@ def setup_py(rest_of_cmdline):
     executable = sys.executable
     if TESTMODE:
         # Hack for testing
-        for unsafe in ['upload', 'register', 'mregister']:
+        for unsafe in ['upload', 'register']:
             if unsafe in rest_of_cmdline:
                 executable = 'echo MOCK'
 


### PR DESCRIPTION
That package was a backport from distutils for Python 2.5 and earlier,
which we do not support.

@reinout, want to have a look to see if my assumptions are wrong and I break something?