### PR TITLE
Warn when no changelog entry has been added.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog for zest.releaser
 3.57 (unreleased)
 -----------------
 
+- Warn when between the last postrelease and a new prerelease no
+  changelog entry has been added.  '- Nothing changed yet' would still
+  be in there.
+  Issue #26.
+  [maurits]
+
 - Fix a random test failure on Travis CI, by resetting
   ``AUTO_RESPONSE``.
   [maurits]

--- a/zest/releaser/tests/fullrelease.txt
+++ b/zest/releaser/tests/fullrelease.txt
@@ -82,6 +82,11 @@ An alternative is to set a ``no-input`` option in the ``setup.cfg`` file:
     ... """
     >>> open('setup.cfg', 'w').write(cfg)
 
+The prerelease part would complain when the changelog still contains
+'- Nothing changed yet.'  So change it.
+
+    >>> add_changelog_entry()
+
 Now run the fullrelease:
 
     >>> from zest.releaser import fullrelease
@@ -108,3 +113,12 @@ The changelog and setup.py are at 0.3.dev0 now:
     import os.path
     <BLANKLINE>
     version = '0.3.dev0'
+
+When you do some commits, but forget to update the changelog,
+prerelease (or fullrelease) will warn you, as indicated earlier:
+
+    >>> from zest.releaser import prerelease
+    >>> prerelease.main()
+    Traceback (most recent call last):
+    ...
+    RuntimeError: SYSTEM EXIT (code=0)

--- a/zest/releaser/tests/functional.py
+++ b/zest/releaser/tests/functional.py
@@ -9,6 +9,7 @@ import urllib2
 import StringIO
 
 from zest.releaser import utils
+from zest.releaser.postrelease import NOTHING_CHANGED_YET
 from zest.releaser.utils import system
 
 
@@ -134,6 +135,13 @@ def setup(test):
         for line in lines[:5]:
             print line,
 
+    def add_changelog_entry():
+        # Replace '- Nothing changed yet.'  by a different entry.
+        orig_changes = open('CHANGES.txt').read()
+        new_changes = orig_changes.replace(
+            NOTHING_CHANGED_YET, '- Brown bag release.')
+        open('CHANGES.txt', 'w').write(new_changes)
+
     test.globs.update({'tempdir': test.tempdir,
                        'repo_url': repo_url,
                        'svnsourcedir': svnsourcedir,
@@ -146,6 +154,7 @@ def setup(test):
                        'bzrhead': bzrhead,
                        'githead': githead,
                        'mock_pypi_available': test.mock_pypi_available,
+                       'add_changelog_entry': add_changelog_entry,
                        })
 
 

--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -104,6 +104,11 @@ The changelog and setup.py are at 0.2 and indicate dev mode:
     <BLANKLINE>
     version = '0.2.dev0'
 
+The prerelease part would complain when the changelog still contains
+'- Nothing changed yet.'  So change it.
+
+    >>> add_changelog_entry()
+
 To check some corner cases we switch back and forth between prerelease
 and postrelease.  The next version after 0.2.19 should not be 0.2.110
 but 0.2.20:
@@ -128,6 +133,7 @@ but 0.2.20:
 Releases without numbers at the end should not fluster us even when we
 cannot suggest a reasonable number. We'll ask for a version until we get one:
 
+    >>> add_changelog_entry()
     >>> utils.test_answer_book.set_answers(['0.3beta', ''])
     >>> prerelease.main()
     Question: Enter version [0.2.20]:
@@ -146,6 +152,7 @@ cannot suggest a reasonable number. We'll ask for a version until we get one:
 
 Numbers and characters can be combined:
 
+    >>> add_changelog_entry()
     >>> utils.test_answer_book.set_answers(['1.0a1', ''])
     >>> prerelease.main()
     Question: Enter version [0.3rc0]:
@@ -164,6 +171,7 @@ Numbers and characters can be combined:
 
 If there's an empty history file, it gets a fresh header.
 
+    >>> add_changelog_entry()
     >>> utils.test_answer_book.set_answers(['1.0', ''])
     >>> prerelease.main()
     Question: ...
@@ -180,6 +188,7 @@ If there's an empty history file, it gets a fresh header.
 If there is no history file, we get no errors and a new history file is not
 created:
 
+    >>> add_changelog_entry()
     >>> utils.test_answer_book.set_answers(['', ''])
     >>> prerelease.main()
     Question: ...


### PR DESCRIPTION
When between the last postrelease and a new prerelease a changelog entry
has not been added, '- Nothing changed yet' would still be in there.

Issue #26.