### PR TITLE
Add '[ci skip]' to commit messages.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog for zest.releaser
 3.57 (unreleased)
 -----------------
 
+- Add ``[ci skip]`` to commit messages to avoid running Travis
+  Continuous Integration builds.  See
+  http://docs.travis-ci.com/user/how-to-skip-a-build/
+  To activate this, add ``[zest.releaser] ci-skip = yes`` to the
+  ``setup.cfg`` of a package, or your global ``~/.pypirc``.
+  [maurits]
+
 - Fix a random test failure on Travis CI, by resetting
   ``AUTO_RESPONSE``.
   [maurits]

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -1,5 +1,6 @@
 """Provide a base for the three releasers"""
 
+import pkg_resources
 from zest.releaser import utils
 from zest.releaser import choose
 from zest.releaser import pypi
@@ -14,6 +15,12 @@ class Basereleaser(object):
         self.setup_cfg = pypi.SetupConfig()
         if self.setup_cfg.no_input():
             utils.AUTO_RESPONSE = True
+        if utils.TESTMODE:
+            pypirc_old = pkg_resources.resource_filename(
+                'zest.releaser.tests', 'pypirc_old.txt')
+            self.pypiconfig = pypi.PypiConfig(pypirc_old)
+        else:
+            self.pypiconfig = pypi.PypiConfig()
 
     def _run_hooks(self, when):
         which_releaser = self.__class__.__name__.lower()
@@ -31,3 +38,8 @@ class Basereleaser(object):
 
     def execute(self):
         raise NotImplementedError()
+
+    def update_commit_message(self, msg):
+        if self.pypiconfig.ci_skip():
+            msg += '\n\n[ci skip]'
+        return msg

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -151,6 +151,7 @@ class Postreleaser(baserelease.Basereleaser):
             logger.info("The '%s':\n\n%s\n" % (diff_cmd, diff))
         if utils.ask("OK to commit this"):
             msg = self.data['commit_msg'] % self.data
+            msg = self.update_commit_message(msg)
             commit_cmd = self.vcs.cmd_commit(msg)
             commit = system(commit_cmd)
             logger.info(commit)

--- a/zest/releaser/prerelease.py
+++ b/zest/releaser/prerelease.py
@@ -150,6 +150,7 @@ class Prereleaser(baserelease.Basereleaser):
             logger.info("The '%s':\n\n%s\n" % (diff_cmd, diff))
         if utils.ask("OK to commit this"):
             msg = self.data['commit_msg'] % self.data
+            msg = self.update_commit_message(msg)
             commit_cmd = self.vcs.cmd_commit(msg)
             commit = system(commit_cmd)
             logger.info(commit)

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -262,3 +262,24 @@ class PypiConfig(object):
         except (NoSectionError, NoOptionError, ValueError):
             return default
         return result
+
+    def ci_skip(self):
+        """Return whether the user wants to skip ci builds.
+
+        This at least works for Travis.  See
+        http://docs.travis-ci.com/user/how-to-skip-a-build/
+
+        Enable this mode by adding a ``ci-skip`` option, either in the
+        package you want to release, or in your ~/.pypirc::
+
+            [zest.releaser]
+            ci-skip = yes
+        """
+        default = False
+        if self.config is None:
+            return default
+        try:
+            result = self.config.getboolean('zest.releaser', 'ci-skip')
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -3,7 +3,6 @@ import logging
 import os
 import urllib2
 import sys
-import pkg_resources
 
 from zest.releaser import baserelease
 from zest.releaser import pypi
@@ -100,12 +99,12 @@ class Releaser(baserelease.Basereleaser):
             print "\nFailed to create tag %s!" % (self.data['version'],)
             sys.exit(1)
 
-    def _upload_distributions(self, package, pypiconfig):
+    def _upload_distributions(self, package):
         # See if creating an sdist actually works.  Also, this makes
         # the sdist available for plugins.
         logger.info("Making an egg of a fresh tag checkout.")
         print system(utils.setup_py('sdist'))
-        if not pypiconfig.is_pypi_configured():
+        if not self.pypiconfig.is_pypi_configured():
             logger.warn("You must have a properly configured %s file in "
                         "your home dir to upload an egg.",
                         pypi.DIST_CONFIG_FILE)
@@ -118,7 +117,7 @@ class Releaser(baserelease.Basereleaser):
             logger.info("This package is registered on PyPI.")
         else:
             logger.warn("This package is NOT registered on PyPI.")
-        if pypiconfig.is_old_pypi_config():
+        if self.pypiconfig.is_old_pypi_config():
             pypi_command = 'register sdist upload'
             shell_command = utils.setup_py(pypi_command)
             if use_pypi:
@@ -139,7 +138,7 @@ class Releaser(baserelease.Basereleaser):
         # If collective.dist is installed (or we are using
         # python2.6 or higher), the user may have defined
         # other servers to upload to.
-        for server in pypiconfig.distutils_servers():
+        for server in self.pypiconfig.distutils_servers():
             if pypi.new_distutils_available():
                 commands = ('register', '-r', server, 'sdist',
                             'upload', '-r', server)
@@ -168,13 +167,6 @@ class Releaser(baserelease.Basereleaser):
 
     def _release(self):
         """Upload the release, when desired"""
-        if utils.TESTMODE:
-            pypirc_old = pkg_resources.resource_filename(
-                'zest.releaser.tests', 'pypirc_old.txt')
-            pypiconfig = pypi.PypiConfig(pypirc_old)
-        else:
-            pypiconfig = pypi.PypiConfig()
-
         # Does the user normally want a real release?  We are
         # interested in getting a sane default answer here, so you can
         # override it in the exceptional case but just hit Enter in
@@ -186,7 +178,7 @@ class Releaser(baserelease.Basereleaser):
             # Expected case: this is a buildout directory.
             default_answer = False
         else:
-            default_answer = pypiconfig.want_release()
+            default_answer = self.pypiconfig.want_release()
 
         if not utils.ask("Check out the tag (for tweaks or pypi/distutils "
                          "server upload)", default=default_answer):
@@ -238,7 +230,7 @@ class Releaser(baserelease.Basereleaser):
         self._run_hooks('after_checkout')
 
         if 'setup.py' in os.listdir(self.data['tagdir']):
-            self._upload_distributions(package, pypiconfig)
+            self._upload_distributions(package)
 
         # Make sure we are in the expected directory again.
         os.chdir(self.vcs.workingdir)

--- a/zest/releaser/tests/functional-bzr.txt
+++ b/zest/releaser/tests/functional-bzr.txt
@@ -126,6 +126,17 @@ And the postrelease script ups the version:
     Question: OK to commit this (Y/n)?
     Our reply: <ENTER>
 
+The commit will contain a hint for Travis to skip the Continuous
+Integration build, because our pypirc has asked this with the ci-skip
+option::
+
+    >>> from zest.releaser import lasttaglog
+    >>> lasttaglog.main()
+    bzr log...
+        Back to development: 0.2
+    <BLANKLINE>
+        [ci skip]...
+
 The changelog and setup.py are at 0.2 and indicate dev mode:
 
     >>> bzrhead('CHANGES.txt')

--- a/zest/releaser/tests/functional-git.txt
+++ b/zest/releaser/tests/functional-git.txt
@@ -130,6 +130,17 @@ And the postrelease script ups the version:
     Question: OK to push commits to the server? (Y/n)?
     Our reply: n
 
+The commit will contain a hint for Travis to skip the Continuous
+Integration build, because our pypirc has asked this with the ci-skip
+option::
+
+    >>> from zest.releaser import lasttaglog
+    >>> lasttaglog.main()
+    git log...
+        Back to development: 0.2
+    <BLANKLINE>
+        [ci skip]...
+
 The changelog and setup.py are at 0.2 and indicate dev mode:
 
     >>> githead('CHANGES.txt')

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -97,6 +97,9 @@ There are two styles of ``.pypirc`` files.  The old one just for pypi:
     [server-login]
     username:pipo_de_clown
     password:asjemenou
+    <BLANKLINE>
+    [zest.releaser]
+    ci-skip = true
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_old)
     >>> pypiconfig.config
     <ConfigParser.ConfigParser instance at ...>
@@ -129,6 +132,9 @@ And the new format that allows multiple uploads:
     repository:http://my.company/products
     username:user
     password:password
+    <BLANKLINE>
+    [zest.releaser]
+    ci-skip = true
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_new)
     >>> pypiconfig.config
     <ConfigParser.ConfigParser instance at ...>

--- a/zest/releaser/tests/pypirc_new.txt
+++ b/zest/releaser/tests/pypirc_new.txt
@@ -17,3 +17,6 @@ password:password
 repository:http://my.company/products
 username:user
 password:password
+
+[zest.releaser]
+ci-skip = true

--- a/zest/releaser/tests/pypirc_old.txt
+++ b/zest/releaser/tests/pypirc_old.txt
@@ -1,3 +1,6 @@
 [server-login]
 username:pipo_de_clown
 password:asjemenou
+
+[zest.releaser]
+ci-skip = true


### PR DESCRIPTION
This avoids running Travis Continuous Integration builds.  See
http://docs.travis-ci.com/user/how-to-skip-a-build/

To activate this, add '[zest.releaser] ci-skip = yes' to the
'setup.cfg' of a package, or your global '~/.pypirc'.

Eric Steele wants something like this for Plone. :-)

Alternatives I can think of:

- Always do this automatically when you have a `.travis.yml` in your repo.

- Do this in a separate package, using the hooks of zest.releaser.