### PR TITLE
Add a tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ zest.releaser.egg-info
 htmlcov
 doc/build/
 
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,4 @@ deps =
     z3c.testsetup
     setuptools >= 8
 commands =
-    zope-testrunner --test-path=. --tests-pattern=^tests$ -v -c
+    zope-testrunner --test-path=. --tests-pattern=^tests$ {posargs:-v -c}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,pypy
+    py26,py27
 
 [testenv]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist =
+    py26,py27,pypy
+
+[testenv]
+usedevelop = true
+deps =
+    zope.testrunner
+    z3c.testsetup
+commands =
+    zope-testrunner --test-path=. --tests-pattern=^tests$ -v -c

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,6 @@ usedevelop = true
 deps =
     zope.testrunner
     z3c.testsetup
+    setuptools >= 8
 commands =
     zope-testrunner --test-path=. --tests-pattern=^tests$ -v -c


### PR DESCRIPTION
tox.ini is becoming the standard way to run tests on an unfamiliar
Python package.  Bonus points: it lets you rest with multiple Python
versions conveniently, which is *essential* should you wish to add
Python 3 support.