### PR TITLE
Maurits postrelease version check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for zest.releaser
 3.57 (unreleased)
 -----------------
 
+- Do not accept ``y`` or ``n`` as answer for a new version.
+  [maurits]
+
 - Warn when between the last postrelease and a new prerelease no
   changelog entry has been added.  '- Nothing changed yet' would still
   be in there.

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -158,6 +158,29 @@ You can also ask for a version number. Pass it as the default value:
     Our reply: 1.0
     '1.0'
 
+Note that ``y`` or ``n`` are not accepted as answer for a version
+number.  I see packages that get version ``y`` in postrelease because
+someone quickly types ``y`` everywhere without looking at the
+question.
+
+    >>> utils.test_answer_book.set_answers(['Y', 'y', 'N', 'n', ''])
+    >>> utils.ask_version('New version', default='72.0')
+    Question: New version [72.0]:
+    Our reply: Y
+    y/n not accepted as version.
+    Question: New version [72.0]:
+    Our reply: y
+    y/n not accepted as version.
+    Question: New version [72.0]:
+    Our reply: N
+    y/n not accepted as version.
+    Question: New version [72.0]:
+    Our reply: n
+    y/n not accepted as version.
+    Question: New version [72.0]:
+    Our reply: <ENTER>
+    '72.0'
+
 
 Not asking input
 ----------------

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -82,7 +82,7 @@ test_answer_book = AnswerBook()
 def get_input(question):
     if not TESTMODE:
         # Normal operation.
-        return raw_input(question)
+        return raw_input(question).strip()
     # Testing means no interactive input. Get it from answers_for_testing.
     print "Question:", question
     answer = test_answer_book.get_next_answer()

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -111,6 +111,10 @@ def ask_version(question, default=None):
     while True:
         input = get_input(question)
         if input:
+            if input.lower() in ('y', 'n'):
+                # Please read the question.
+                print "y/n not accepted as version."
+                continue
             return input
         if default:
             return default


### PR DESCRIPTION
Actually: postrelease *and* prerelease. Any part where we call `ask_version`.

Example commit that we want to avoid here:
https://github.com/plone/plone.app.testing/commit/81c54c6adc72ace456b40cda327f0b8d3bbbf55a
(I have reverted that one in https://github.com/plone/plone.app.testing/commit/24663b9b90d6d849045c75303a0cfc4c4dcbf2d3)