### PR TITLE
Use AST & tokenize to parse Python files rather than relying on regular expressions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog for zest.releaser
   descriptions when we test and render them.
   [mitchellrj]
 
+- Use the AST and tokenizer when parsing and writing Python code files.
+  [mitchellrj]
+
 4.0 (2015-05-21)
 ----------------
 

--- a/zest/releaser/tests/test_setup.py
+++ b/zest/releaser/tests/test_setup.py
@@ -65,7 +65,8 @@ checker = renormalizing.RENormalizing([
     (re.compile(re.escape(Fore.RED)), 'RED '),
     (re.compile(re.escape(Fore.MAGENTA)), 'MAGENTA '),
 ] + ([
-
+    (re.compile('b\''), '\''),
+    (re.compile('b"'), '"'),
 ] if six.PY3 else [
     (re.compile('u\''), '\''),
     (re.compile('u"'), '"'),

--- a/zest/releaser/tests/vcs.txt
+++ b/zest/releaser/tests/vcs.txt
@@ -138,8 +138,106 @@ version.txt is the one left as-is.
           version='1.4',
           )
 
-The version writing breaks down if there's more than just a "version=" on that
-line.  The 99.9% case works, though.
+Let's try a case where someone's been a bit silly and set the version
+in two places in the same file.
+
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "version='1.3'",
+    ...     "setup(name='urgh',",
+    ...     "      version='1.3',",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    version='1.4'
+    setup(name='urgh',
+          version='1.4',
+          )
+
+What if you've done something a bit weird?
+
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "setup(name='urgh',",
+    ...     "      version=('1.3'),",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    setup(name='urgh',
+          version=('1.4'),
+          )
+
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "version = \\",
+    ...     "    '1.3'",
+    ...     "setup(name='urgh',",
+    ...     "      version=version,",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    version = \
+        '1.4'
+    setup(name='urgh',
+          version=version,
+          )
+
+Or used a different string syntax?
+
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "setup(name='urgh',",
+    ...     "      version='''1.3''',",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    setup(name='urgh',
+          version='1.4',
+          )
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "setup(name='urgh',",
+    ...     "      version=r'1.3',",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    setup(name='urgh',
+          version='1.4',
+          )
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "setup(name='urgh',",
+    ...     "      version=b'1.3',",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    setup(name='urgh',
+          version='1.4',
+          )
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "setup(name='urgh',",
+    ...     "      version=u'1.3',",
+    ...     "      )"]
+    >>> dont_care = open('setup.py', 'w').write('\n'.join(lines))
+    >>> checkout.version = '1.4'
+    >>> print(open('setup.py').read()) # Modified into 1.4
+    from setuptools import setup
+    setup(name='urgh',
+          version='1.4',
+          )
 
 Another option is a ``__version__`` marker in a Python file. We cannot
 reliably figure out the right Python file to look in, so this file needs to be


### PR DESCRIPTION
Gains: more reliable
Losses: less readable

This has been made more readable than it was in #97.