### PR TITLE
Add support for projects with setup.py located in subdirectories.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Changelog for zest.releaser
   wheel.  Issue #108.
   [maurits]
 
-- Add support for projects with setup.py located in subdirectories.
+- Add a `--package-root` option to support projects where `setup.py` is not
+  located at the top level of the repository.
 
 
 5.0 (2015-06-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Changelog for zest.releaser
   wheel.  Issue #108.
   [maurits]
 
+- Add support for projects with setup.py located in subdirectories.
+
 
 5.0 (2015-06-05)
 ----------------

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -9,6 +9,8 @@ from six.moves.configparser import ConfigParser
 from six.moves.configparser import NoSectionError
 from six.moves.configparser import NoOptionError
 
+from zest.releaser import utils
+
 try:
     pkg_resources.get_distribution('wheel')
 except pkg_resources.DistributionNotFound:
@@ -43,7 +45,7 @@ class SetupConfig(object):
     def __init__(self):
         """Grab the configuration (overridable for test purposes)"""
         # If there is a setup.cfg in the package, parse it
-        if not os.path.exists(self.config_filename):
+        if not os.path.exists(os.path.join(utils.PACKAGE_ROOT, self.config_filename)):
             self.config = None
             return
         self.config = ConfigParser()

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -526,7 +526,7 @@ sys.executable.
 
     >>> cmd = utils.setup_py('cook a cow')
     >>> print(cmd.replace(sys.executable, 'python'))  # test normalization
-    python setup.py cook a cow
+    python ./setup.py cook a cow
 
 When the setup.py arguments include arguments that indicate pypi interaction,
 the python executable is replaced by ``echo`` for safety reasons.  This only
@@ -534,9 +534,9 @@ happens when TESTMODE is on:
 
     >>> utils.TESTMODE = True
     >>> print(utils.setup_py('upload'))
-    echo MOCK setup.py upload
+    echo MOCK ./setup.py upload
     >>> print(utils.setup_py('register'))
-    echo MOCK setup.py register
+    echo MOCK ./setup.py register
 
 
 Data dict documentation

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -32,7 +32,7 @@ WRONG_IN_VERSION = ['svn', 'dev', '(']
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
 
 AUTO_RESPONSE = False
-BASE = "."
+BASE = os.curdir
 VERBOSE = False
 INPUT_ENCODING = 'UTF-8'
 if getattr(sys.stdin, 'encoding', None):

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -32,6 +32,7 @@ WRONG_IN_VERSION = ['svn', 'dev', '(']
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
 
 AUTO_RESPONSE = False
+BASE = "."
 VERBOSE = False
 INPUT_ENCODING = 'UTF-8'
 if getattr(sys.stdin, 'encoding', None):
@@ -133,7 +134,12 @@ def cleanup_version(version):
 def parse_options():
     global AUTO_RESPONSE
     global VERBOSE
+    global BASE
     parser = ArgumentParser()
+    parser.add_argument(
+        "--base",
+        default=BASE,
+        help="Directory containing setup.py")
     parser.add_argument(
         "--no-input",
         action="store_true",
@@ -150,6 +156,7 @@ def parse_options():
     options = parser.parse_args()
     AUTO_RESPONSE = options.auto_response
     VERBOSE = options.verbose
+    BASE = options.base
 
 
 # Hack for testing, see get_input()
@@ -371,7 +378,9 @@ def setup_py(rest_of_cmdline):
             if unsafe in rest_of_cmdline:
                 executable = 'echo MOCK'
 
-    return '%s setup.py %s' % (executable, rest_of_cmdline)
+    setup_py = os.path.join(BASE, 'setup.py')
+
+    return ' '.join([executable, setup_py, rest_of_cmdline])
 
 
 def twine_command(rest_of_cmdline):

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -32,7 +32,7 @@ WRONG_IN_VERSION = ['svn', 'dev', '(']
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
 
 AUTO_RESPONSE = False
-BASE = os.curdir
+PACKAGE_ROOT = os.curdir
 VERBOSE = False
 INPUT_ENCODING = 'UTF-8'
 if getattr(sys.stdin, 'encoding', None):
@@ -134,11 +134,11 @@ def cleanup_version(version):
 def parse_options():
     global AUTO_RESPONSE
     global VERBOSE
-    global BASE
+    global PACKAGE_ROOT
     parser = ArgumentParser()
     parser.add_argument(
-        "--base",
-        default=BASE,
+        "--package-root",
+        default=PACKAGE_ROOT,
         help="Directory containing setup.py")
     parser.add_argument(
         "--no-input",
@@ -156,7 +156,7 @@ def parse_options():
     options = parser.parse_args()
     AUTO_RESPONSE = options.auto_response
     VERBOSE = options.verbose
-    BASE = options.base
+    PACKAGE_ROOT = options.package_root
 
 
 # Hack for testing, see get_input()
@@ -378,7 +378,7 @@ def setup_py(rest_of_cmdline):
             if unsafe in rest_of_cmdline:
                 executable = 'echo MOCK'
 
-    setup_py = os.path.join(BASE, 'setup.py')
+    setup_py = os.path.join(PACKAGE_ROOT, 'setup.py')
 
     return ' '.join([executable, setup_py, rest_of_cmdline])
 

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -48,7 +48,7 @@ class BaseVersionControl(object):
         return True
 
     def get_setup_py_version(self):
-        if os.path.exists('setup.py'):
+        if os.path.exists(os.path.join(utils.BASE, 'setup.py')):
             # First run egg_info, as that may get rid of some warnings
             # that otherwise end up in the extracted version, like
             # UserWarnings.
@@ -65,7 +65,7 @@ class BaseVersionControl(object):
             return utils.strip_version(version)
 
     def get_setup_py_name(self):
-        if os.path.exists('setup.py'):
+        if os.path.exists(os.path.join(utils.BASE, 'setup.py')):
             # First run egg_info, as that may get rid of some warnings
             # that otherwise end up in the extracted name, like
             # UserWarnings.
@@ -220,7 +220,9 @@ class BaseVersionControl(object):
 
         good_version = "version = '%s'" % version
         line_number = 0
-        setup_lines = utils.read_text_file('setup.py').split('\n')
+        setup_py = os.path.join(utils.BASE, 'setup.py')
+
+        setup_lines = utils.read_text_file(setup_py).split('\n')
         for line_number, line in enumerate(setup_lines):
             match = VERSION_PATTERN.search(line)
             if match:
@@ -232,7 +234,7 @@ class BaseVersionControl(object):
                     good_version = indentation + "version='%s'," % version
                 setup_lines[line_number] = good_version
                 contents = '\n'.join(setup_lines)
-                open('setup.py', 'w').write(contents)
+                open(setup_py, 'w').write(contents)
                 logger.info("Set setup.py's version to %r", version)
                 return
 
@@ -318,7 +320,7 @@ class BaseVersionControl(object):
         works is handy for the vcs.txt tests.
         """
         files = []
-        for dirpath, dirnames, filenames in os.walk('.'):
+        for dirpath, dirnames, filenames in os.walk(utils.BASE):
             dirnames  # noqa pylint
             for filename in filenames:
                 files.append(os.path.join(dirpath, filename))

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -320,7 +320,7 @@ class BaseVersionControl(object):
         works is handy for the vcs.txt tests.
         """
         files = []
-        for dirpath, dirnames, filenames in os.walk(utils.PACKAGE_ROOT):
+        for dirpath, dirnames, filenames in os.walk(os.curdir):
             dirnames  # noqa pylint
             for filename in filenames:
                 files.append(os.path.join(dirpath, filename))

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -48,7 +48,7 @@ class BaseVersionControl(object):
         return True
 
     def get_setup_py_version(self):
-        if os.path.exists(os.path.join(utils.BASE, 'setup.py')):
+        if os.path.exists(os.path.join(utils.PACKAGE_ROOT, 'setup.py')):
             # First run egg_info, as that may get rid of some warnings
             # that otherwise end up in the extracted version, like
             # UserWarnings.
@@ -65,7 +65,7 @@ class BaseVersionControl(object):
             return utils.strip_version(version)
 
     def get_setup_py_name(self):
-        if os.path.exists(os.path.join(utils.BASE, 'setup.py')):
+        if os.path.exists(os.path.join(utils.PACKAGE_ROOT, 'setup.py')):
             # First run egg_info, as that may get rid of some warnings
             # that otherwise end up in the extracted name, like
             # UserWarnings.
@@ -220,7 +220,7 @@ class BaseVersionControl(object):
 
         good_version = "version = '%s'" % version
         line_number = 0
-        setup_py = os.path.join(utils.BASE, 'setup.py')
+        setup_py = os.path.join(utils.PACKAGE_ROOT, 'setup.py')
 
         setup_lines = utils.read_text_file(setup_py).split('\n')
         for line_number, line in enumerate(setup_lines):
@@ -320,7 +320,7 @@ class BaseVersionControl(object):
         works is handy for the vcs.txt tests.
         """
         files = []
-        for dirpath, dirnames, filenames in os.walk(utils.BASE):
+        for dirpath, dirnames, filenames in os.walk(utils.PACKAGE_ROOT):
             dirnames  # noqa pylint
             for filename in filenames:
                 files.append(os.path.join(dirpath, filename))


### PR DESCRIPTION
Consider a  repo with a file structure like this:
```
repo/
  foo/
      setup.py
  .git
```

It may not be the recommended structure for a python project, but it happens in practice.

Running `fullrelease` from within `repo`:

```
$ fullrelease
INFO: Starting prerelease.
CRITICAL: No version found.
```

Running it from within `foo`:

```
$ fullrelease
INFO: Starting prerelease.
CRITICAL: No version control system detected.
```

With this change, from within `repo`:
```
$ fullrelease --base foo
INFO: Starting prerelease.
...
```

I thought about maybe trying to be smart by recursing to find the file, but I prefer this explicitness. Let me know what you think!