### PR TITLE
Always use --non-interactive for svn commands.

### DIFF
--- a/zest/releaser/svn.py
+++ b/zest/releaser/svn.py
@@ -98,7 +98,7 @@ class Subversion(BaseVersionControl):
             else:
                 sys.exit(0)
 
-        tag_info = execute_command('svn list %s%s' % (base, tags_name))
+        tag_info = execute_command('svn list --non-interactive %s%s' % (base, tags_name))
         network_errors = [
             'Could not resolve hostname',
             'E670008',
@@ -125,10 +125,10 @@ class Subversion(BaseVersionControl):
         return base + self._tags_name + '/' + version
 
     def cmd_diff(self):
-        return 'svn diff'
+        return 'svn diff --non-interactive'
 
     def cmd_commit(self, message):
-        return 'svn commit -m "%s"' % message
+        return 'svn commit --non-interactive -m "%s"' % message
 
     def cmd_diff_last_commit_against_tag(self, version):
         url = self._svn_info()
@@ -141,7 +141,7 @@ class Subversion(BaseVersionControl):
         """
         url = self._svn_info()
         tag_url = self.tag_url(version)
-        tag_info = execute_command('svn info %s' % tag_url)
+        tag_info = execute_command('svn info--non-interactive %s' % tag_url)
         # Search for: Last Changed Rev: 42761
         revision = None
         for line in tag_info.split('\n'):
@@ -157,11 +157,11 @@ class Subversion(BaseVersionControl):
     def cmd_create_tag(self, version):
         url = self._svn_info()
         tag_url = self.tag_url(version)
-        return 'svn cp %s %s -m "Tagging %s"' % (url, tag_url, version)
+        return 'svn cp --non-interactive %s %s -m "Tagging %s"' % (url, tag_url, version)
 
     def cmd_checkout_from_tag(self, version, checkout_dir):
         tag_url = self.tag_url(version)
-        return 'svn co %s %s' % (tag_url, checkout_dir)
+        return 'svn co --non-interactive %s %s' % (tag_url, checkout_dir)
 
     def is_clean_checkout(self):
         """Is this a clean checkout?
@@ -177,4 +177,4 @@ class Subversion(BaseVersionControl):
 
     def list_files(self):
         """List files in version control."""
-        return execute_command('svn ls --recursive').splitlines()
+        return execute_command('svn ls --non-interactive --recursive').splitlines()

--- a/zest/releaser/tests/functional-svn.txt
+++ b/zest/releaser/tests/functional-svn.txt
@@ -88,7 +88,7 @@ The release script tags the release and uploads it:
     >>> release.main()
     Checking data dict
     Tag needed to proceed, you can use the following command:
-    svn cp file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m "Tagging 0.1"
+    svn cp --non-interactive file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m "Tagging 0.1"
     Question: Run this command (Y/n)?
     Our reply: y
     <BLANKLINE>

--- a/zest/releaser/tests/svn.txt
+++ b/zest/releaser/tests/svn.txt
@@ -40,7 +40,7 @@ Make a change:
     >>> dont_care = open(setup_py, 'a').write('\na = 2\n')
     >>> cmd = checkout.cmd_diff()
     >>> cmd
-    'svn diff'
+    'svn diff --non-interactive'
     >>> print(execute_command(cmd))
     Index: ...
     --- setup.py      (revision 3)
@@ -56,7 +56,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    'svn commit -m "small tweak"'
+    'svn commit --non-interactive -m "small tweak"'
     >>> print(execute_command(cmd))
     Sending        setup.py
     Transmitting file data...
@@ -79,7 +79,7 @@ Create a tag and it will show up:
 
     >>> cmd = checkout.cmd_create_tag('0.1')
     >>> cmd
-    'svn cp file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m "Tagging 0.1"'
+    'svn cp --non-interactive file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m "Tagging 0.1"'
     >>> dont_care = execute_command(cmd)
     >>> checkout.available_tags()
     ['0.1']
@@ -133,7 +133,7 @@ The tag checkout command makes a checkout in that tempdir:
 
     >>> cmd = checkout.cmd_checkout_from_tag('0.1', temp)
     >>> cmd
-    'svn co file://TESTREPO/tha.example/tags/0.1 TMPDIR/somename...'
+    'svn co --non-interactive file://TESTREPO/tha.example/tags/0.1 TMPDIR/somename...'
     >>> print('\n'.join(sorted(execute_command(cmd).splitlines())))
     A    TMPDIR/somename.../CHANGES.txt
     A    TMPDIR/somename.../README.txt
@@ -308,10 +308,10 @@ Tag and checkout commands also use the singular:
 
     >>> cmd = singular_checkout.cmd_checkout_from_tag('0.1', temp)
     >>> cmd
-    'svn co file://TESTREPO/singular/tag/0.1 TMPDIR/somename...'
+    'svn co --non-interactive file://TESTREPO/singular/tag/0.1 TMPDIR/somename...'
     >>> cmd = singular_checkout.cmd_create_tag('0.1')
     >>> cmd
-    'svn cp file://TESTREPO/singular/trunk file://TESTREPO/singular/tag/0.1 -m "Tagging 0.1"'
+    'svn cp --non-interactive file://TESTREPO/singular/trunk file://TESTREPO/singular/tag/0.1 -m "Tagging 0.1"'
 
 If we have branch checkout, the base url is still extracted correctly, even if
 the singular /tag and /branch is used:


### PR DESCRIPTION
If there are certificate errors these are silently dropped into output making for strange behaviour without this option.