### PR TITLE
When using the '--no-input' option, show question and answer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog for zest.releaser
 ----------------
 
 - When using the ``--no-input`` option, show the question and the
-  chosen answer.  Otherwise in case of a problem it was not clear why
+  chosen answer.  Otherwise in case of a problem it is not clear why
   the command stopped.
   Fixes issue #136.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog for zest.releaser
 5.8 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- When using the ``--no-input`` option, show the question and the
+  chosen answer.  Otherwise in case of a problem it was not clear why
+  the command stopped.
+  Fixes issue #136.
+  [maurits]
 
 
 5.7 (2015-10-14)

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -230,8 +230,8 @@ def ask_version(question, default=None):
                    "question: %s")
             msg = msg % question
             raise RuntimeError(msg)
-        logger.debug("Auto-responding '%s' to the question below.", default)
-        logger.debug(question)
+        logger.info(question)
+        logger.info("Auto-responding '%s'.", default)
         return default
     if default:
         question += " [%s]: " % default
@@ -265,9 +265,8 @@ def ask(question, default=True, exact=False):
                    "we're running in --no-input mode.")
             msg = msg % question
             raise RuntimeError(msg)
-        logger.debug("Auto-responding '%s' to the question below.",
-                     default and "yes" or "no")
-        logger.debug(question)
+        logger.info(question)
+        logger.info("Auto-responding '%s'.", "yes" if default else "no")
         return default
     while True:
         yn = 'y/n'


### PR DESCRIPTION
Otherwise in case of a problem it was not clear why the command
stopped.

Done simply by changing logger.debug to logger.info...

Also switched the order around: first show the question, then the
answer we give.

Fixes issue #136.