### PR TITLE
Show changelog of current release before asking for new version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 6.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Show changelog of current release before asking for the new version
+  number.  Issue #155.  [maurits]
+
 
 
 6.5 (2016-01-05)

--- a/zest/releaser/tests/fullrelease.txt
+++ b/zest/releaser/tests/fullrelease.txt
@@ -52,6 +52,13 @@ Now run the fullrelease:
     >>> from zest.releaser import fullrelease
     >>> fullrelease.main()
     lists of files in version control and sdist match
+    Changelog entries for version 0.1:
+    <BLANKLINE>
+    0.1 (1972-12-25)
+    ----------------
+    <BLANKLINE>
+    - Initial library skeleton created by thaskel.  [your name]
+    <BLANKLINE>
     Checking data dict
     Checking data dict
     Tag needed ...
@@ -94,6 +101,16 @@ Now run the fullrelease:
     >>> from zest.releaser import fullrelease
     >>> fullrelease.main()
     lists of files in version control and sdist match
+    Changelog entries for version 0.2:
+    <BLANKLINE>
+    0.2 (1972-12-25)
+    ----------------
+    <BLANKLINE>
+    - Brown bag release.
+    <BLANKLINE>
+    <BLANKLINE>
+    0.1 (1972-12-25)
+    ----------------
     Checking data dict
     Checking data dict
     Tag needed ...


### PR DESCRIPTION
Issue #155.

Implementation: we grab the version and the history twice:

- Initially in read-only mode: check current version and history and
  maybe warn about problems.

- Then show the changelog of the current release as found in the
  history.  Include the header and underline of the previous release
  for reference.

- Then grab the version in write mode: ask for the new version number.

- Then grab the history in write mode: take over the new version number.