### PR TITLE
Add "no-input" to global options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog for zest.releaser
 6.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added ``no-input`` option also to global (.pypirc) options.
+  Issue #164.  [jcerjak]
 
 
 6.6.1 (2016-02-02)

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -30,14 +30,14 @@ class Basereleaser(object):
                      'reporoot': self.vcs.reporoot,
                      'name': self.vcs.name}
         self.setup_cfg = pypi.SetupConfig()
-        if self.setup_cfg.no_input():
-            utils.AUTO_RESPONSE = True
         if utils.TESTMODE:
             pypirc_old = pkg_resources.resource_filename(
                 'zest.releaser.tests', 'pypirc_old.txt')
             self.pypiconfig = pypi.PypiConfig(pypirc_old)
         else:
             self.pypiconfig = pypi.PypiConfig()
+        if self.pypiconfig.no_input():
+            utils.AUTO_RESPONSE = True
 
     def _grab_version(self):
         """Just grab the version.

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -33,7 +33,7 @@ class SetupConfig(object):
     Another is for optional zest.releaser-specific settings::
 
         [zest.releaser]
-        no-input = yes
+        python-file-with-version = reinout/maurits.py
 
 
     """
@@ -89,29 +89,6 @@ class SetupConfig(object):
             new_setup.close()
         logger.info("New setup.cfg contents:")
         print(''.join(open(self.config_filename).readlines()))
-
-    def no_input(self):
-        """Return whether the user wants to run in no-input mode.
-
-        Enable this mode by adding a ``no-input`` option::
-
-            [zest.releaser]
-            no-input = yes
-
-        The default when this option has not been set is False.
-
-        Standard config rules apply, so you can use upper or lower or
-        mixed case and specify 0, false, no or off for boolean False,
-        and 1, on, true or yes for boolean True.
-        """
-        default = False
-        if self.config is None:
-            return default
-        try:
-            result = self.config.getboolean('zest.releaser', 'no-input')
-        except (NoSectionError, NoOptionError, ValueError):
-            return default
-        return result
 
     def python_file_with_version(self):
         """Return Python filename with ``__version__`` marker, if configured.
@@ -297,6 +274,29 @@ class PypiConfig(object):
             return default
         try:
             result = self.config.getboolean('zest.releaser', 'create-wheel')
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
+
+    def no_input(self):
+        """Return whether the user wants to run in no-input mode.
+
+        Enable this mode by adding a ``no-input`` option::
+
+            [zest.releaser]
+            no-input = yes
+
+        The default when this option has not been set is False.
+
+        Standard config rules apply, so you can use upper or lower or
+        mixed case and specify 0, false, no or off for boolean False,
+        and 1, on, true or yes for boolean True.
+        """
+        default = False
+        if self.config is None:
+            return default
+        try:
+            result = self.config.getboolean('zest.releaser', 'no-input')
         except (NoSectionError, NoOptionError, ValueError):
             return default
         return result

--- a/zest/releaser/tests/fullrelease.txt
+++ b/zest/releaser/tests/fullrelease.txt
@@ -78,7 +78,8 @@ The changelog and setup.py are at 0.2.dev0:
     <BLANKLINE>
     version = '0.2.dev0'
 
-An alternative is to set a ``no-input`` option in the ``setup.cfg`` file:
+An alternative is to set a ``no-input`` option in the ``.pypirc`` or
+``setup.cfg`` file:
 
     >>> sys.argv[1:] = []
     >>> from zest.releaser import utils

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -296,7 +296,18 @@ The default is False:
     >>> pypiconfig.no_input()
     False
 
-Enable the option:
+Enable the option in ``.pypirc``:
+
+    >>> pypirc_no_input = pkg_resources.resource_filename(
+    ...     'zest.releaser.tests', 'pypirc_no_input.txt')
+    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_no_input)
+
+Now the option should be set to True:
+
+    >>> pypiconfig.no_input()
+    True
+
+Let's enable the option also in setup.cfg:
 
     >>> SETUP_CFG = """
     ... [zest.releaser]
@@ -305,6 +316,9 @@ Enable the option:
     >>> with open(pypi.SETUP_CONFIG_FILE, 'w') as f:
     ...     _ = f.write(SETUP_CFG)
     >>> pypiconfig = pypi.PypiConfig()
+
+The option should be set to True here as well:
+
     >>> pypiconfig.no_input()
     True
 

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -288,11 +288,12 @@ No-input mode
 In some cases you want no questions asked. Zest.releaser should just do its
 job without asking for versions or confirmations. You can enable this
 behaviour with a ``--no-input`` commandline option, but also by adding
-``no-input = yes`` to the ``[zest.releaser]`` section in ``setup.cfg``.
+``no-input = yes`` to the ``[zest.releaser]`` section in ``.pypirc`` or
+``setup.cfg``.
 
 The default is False:
 
-    >>> setup_config.no_input()
+    >>> pypiconfig.no_input()
     False
 
 Enable the option:
@@ -303,8 +304,8 @@ Enable the option:
     ... """
     >>> with open(pypi.SETUP_CONFIG_FILE, 'w') as f:
     ...     _ = f.write(SETUP_CFG)
-    >>> setup_config = pypi.SetupConfig()
-    >>> setup_config.no_input()
+    >>> pypiconfig = pypi.PypiConfig()
+    >>> pypiconfig.no_input()
     True
 
 

--- a/zest/releaser/tests/pypirc_no_input.txt
+++ b/zest/releaser/tests/pypirc_no_input.txt
@@ -1,0 +1,10 @@
+[distutils]
+index-servers =
+    pypi
+
+[pypi]
+username:user
+password:password
+
+[zest.releaser]
+no-input = yes


### PR DESCRIPTION
This provides a fix for https://github.com/zestsoftware/zest.releaser/issues/164