### PR TITLE
Do a shallow clone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog for zest.releaser
 6.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do a shallow clone to speed up release (specially noticeable on big repositories).
+  Issue #169 [gforcada]
 
 
 6.6.2 (2016-02-11)

--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -49,7 +49,7 @@ class Git(BaseVersionControl):
         temp = tempfile.mkdtemp(prefix=prefix)
         cwd = os.getcwd()
         os.chdir(temp)
-        cmd = 'git clone %s %s' % (self.reporoot, 'gitclone')
+        cmd = 'git clone --depth 1 %s %s' % (self.reporoot, 'gitclone')
         logger.debug(execute_command(cmd))
         clonedir = os.path.join(temp, 'gitclone')
         os.chdir(clonedir)


### PR DESCRIPTION
This will improve the release time a lot on big repositories.

See https://github.com/zestsoftware/zest.releaser/issues/169