### PR TITLE
Support overriding the default development marker in setup.cfg

### DIFF
--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -15,7 +15,7 @@ TODAY = datetime.datetime.today().strftime('%Y-%m-%d')
 HISTORY_HEADER = '%(new_version)s (unreleased)'
 NOTHING_CHANGED_YET = '- Nothing changed yet.'
 COMMIT_MSG = 'Back to development: %(new_version)s'
-DEV_VERSION_TEMPLATE = '%(new_version)s.dev0'
+DEV_VERSION_TEMPLATE = '%(new_version)s%(development_marker)s'
 
 DATA = {
     # Documentation for self.data.  You get runtime warnings when something is
@@ -38,6 +38,7 @@ DATA = {
     'history_insert_line_here': (
         'Line number where an extra changelog entry can be inserted.'),
     'dev_version_template': 'Template for dev version number',
+    'development_marker': 'String to be appended to version after postrelease'
 }
 
 
@@ -51,11 +52,14 @@ class Postreleaser(baserelease.Basereleaser):
     def __init__(self, vcs=None):
         baserelease.Basereleaser.__init__(self, vcs=vcs)
         # Prepare some defaults for potential overriding.
+        development_marker = self.setup_cfg.development_marker()
+
         self.data.update(dict(
             nothing_changed_yet=NOTHING_CHANGED_YET,
             commit_msg=COMMIT_MSG,
             history_header=HISTORY_HEADER,
-            dev_version_template=DEV_VERSION_TEMPLATE))
+            dev_version_template=DEV_VERSION_TEMPLATE,
+            development_marker=development_marker))
 
     def prepare(self):
         """Prepare self.data by asking about new dev version"""
@@ -80,7 +84,8 @@ class Postreleaser(baserelease.Basereleaser):
         current = utils.cleanup_version(current)
         suggestion = utils.suggest_version(current)
         print("Current version is %s" % current)
-        q = "Enter new development version ('.dev0' will be appended)"
+        q = ("Enter new development version "
+             "('%(development_marker)s' will be appended)" % self.data)
         version = utils.ask_version(q, default=suggestion)
         if not version:
             version = suggestion

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -66,7 +66,7 @@ class SetupConfig(object):
             result = self.config.get('zest.releaser',
                                      'development-marker')
         except (NoSectionError, NoOptionError, ValueError):
-            result = "dev0"
+            result = ".dev0"
         return result
 
     def has_bad_commands(self):

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -50,6 +50,25 @@ class SetupConfig(object):
         with codecs.open(self.config_filename, 'r', 'utf8') as fp:
             self.config.readfp(fp)
 
+    def development_marker(self):
+        """Return development marker to be appended in postrelease
+
+        Override the default ``.dev0`` in setup.cfg using
+        a ``development-marker`` option::
+
+            [zest.releaser]
+            development-marker = .dev1
+
+        Returns default of `.dev0` when nothing has been configured.
+
+        """
+        try:
+            result = self.config.get('zest.releaser',
+                                     'development-marker')
+        except (NoSectionError, NoOptionError, ValueError):
+            result = "dev0"
+        return result
+
     def has_bad_commands(self):
         if self.config is None:
             return False


### PR DESCRIPTION
This allows for overriding the default development marker of .dev0 with one specified in setup.cfg
within the zest.releaser section.

There are probably some additional changes that need to be made (haven't touched docs or other 
related files). Figured I'd see earlier on if this is something that would be considered added to zest.releaser.

It didn't seem like this is something that was do-able as a plugin.
