### PR TITLE
Updated tox.ini and docs to reflect testing with Python 3.5

### DIFF
--- a/doc/source/developing.rst
+++ b/doc/source/developing.rst
@@ -16,8 +16,8 @@ zest.releaser checkout, do this::
 Python versions
 ---------------
 
-The tests currently pass on python 2.7, 3.3 & 3.4. Travis continuous
-integration tests 2.7, 3.3 & 3.4 for us automatically.
+The tests currently pass on python 2.7, 3.3, 3.4 & 3.5. Travis continuous
+integration tests 2.7, 3.3, 3.4 & 3.5 for us automatically.
 
 
 Necessary programs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,pypy,pypy3
+    py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Python 3.5 has been used for testing by Travis since the 21st of April 2016. This PR updates the docs to reflect this and adds a py35 environment to ``tox.ini`` too.