### PR TITLE
Mentions support for a CHANGES file with extension .md in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ are:
 
 - **prerelease**: asks you for a version number (defaults to the current
   version minus a 'dev' or so), updates the setup.py or version.txt and the
-  CHANGES/HISTORY/CHANGELOG file (with either .rst/.txt/.markdown or no
+  CHANGES/HISTORY/CHANGELOG file (with either .rst/.txt/.md/.markdown or no
   extension) with this new version number and offers to commit those changes
   to subversion (or bzr or hg or git)
 


### PR DESCRIPTION
zest.releaser recognizes a CHANGES file with extension md. The README only mentioned extensions rst, txt, and markdown, or no extension at all. I could not imagine .md was not recognized so I looked through the code and see there, it is supported. To avoid other developers having to do the same, I updated the README.