### PR TITLE
Fixed tests with git 2.9.1+.

### DIFF
--- a/zest/releaser/tests/test_setup.py
+++ b/zest/releaser/tests/test_setup.py
@@ -72,6 +72,9 @@ checker = renormalizing.RENormalizing([
     # Change in git 1.8.0:
     (re.compile('nothing to commit \(working directory clean\)'),
      'nothing to commit, working directory clean'),
+    # Change in git 2.9.1:
+    (re.compile('nothing to commit, working directory clean'),
+     'nothing to commit, working tree clean'),
     # Change in git 1.8.5, the hash is removed:
     (re.compile('# On branch'),
      'On branch'),


### PR DESCRIPTION
I got this failure locally:

```
File "/Users/maurits/tools/src/zest.releaser/zest/releaser/tests/functional-git.txt", line 163, in functional-git.txt
Failed example:
    print(execute_command("git status"))
Differences (ndiff with -expected +actual):
      On branch master
    - nothing to commit, working directory clean
    ?                            ^^  ^^^^^
    + nothing to commit, working tree clean
    ?                            ^  ^
    + <BLANKLINE>
```

See explanation for the change in this git commit: https://github.com/git/git/commit/2a0e6cdedab306eccbd297c051035c13d0266343

This pull request fixes our tests.