### PR TITLE
Support and require twine 1.8.0 as minimum version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog for zest.releaser
 6.6.5 (unreleased)
 ------------------
 
+- Support and require twine 1.8.0 as minimum version.
+  Fixes https://github.com/zestsoftware/zest.releaser/issues/183
+  [maurits]
+
 - Updated the documentation on uploading.  [mgedmin, maurits]
 
 - Replaced http://zestreleaser.readthedocs.org with

--- a/doc/source/uploading.rst
+++ b/doc/source/uploading.rst
@@ -99,6 +99,12 @@ is now a core dependency, installed automatically.
 
 .. _twine: https://pypi.python.org/pypi/twine
 
+Note that we call functions in ``twine`` that may change their call
+signature, so if you get strange errors, you may be using a too new
+version of ``twine``.  Please open an `issue
+<https://github.com/zestsoftware/zest.releaser/issues/new>`_ then.
+Currently, it works with ``twine`` 1.8.x.
+
 
 Uploading wheels
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(name='zest.releaser',
           'setuptools',
           'colorama',
           'six',
-          'twine >= 1.6.0',
+          'twine >= 1.8.0',
       ],
       extras_require={
           'recommended': [

--- a/zest/releaser/tests/test_setup.py
+++ b/zest/releaser/tests/test_setup.py
@@ -12,15 +12,20 @@ from twine.commands import upload
 
 
 def mock_register(package, repository, username, password, comment,
-                  config_file):
+                  config_file, cert, client_cert, repository_url):
     """Replacement for twine register command.
+
+    Please keep in sync with twine/commands/register.py.
     """
     print('MOCK twine register -r {} {}'.format(repository, package))
 
 
-def mock_upload(dists, repository, sign, identity, username, password, comment,
-                sign_with, config_file, skip_existing):
+def mock_upload(dists, repository, sign, identity, username, password,
+               comment, sign_with, config_file, skip_existing,
+               cert, client_cert, repository_url):
     """Replacement for twine upload command.
+
+    Please keep in sync with twine/commands/upload.py.
     """
     print('MOCK twine upload -r {} {}'.format(repository, ' '.join(dists)))
 

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -736,12 +736,29 @@ def retry_twine(twine_command, server, *files):
     if isinstance(files, six.text_type):
         files = [files]
     if twine_command == 'register':
+        # There is currently no stable API for twine register.
+        # See https://github.com/zestsoftware/zest.releaser/issues/183
+        # It is 'semi-stable'.  It may get new arguments.
+        # def register(package, repository, username, password, comment,
+        #              config_file, cert, client_cert, repository_url):
+        # If you change the call here, you probably need to change
+        # our mock_register function in tests/test_setup.py.
         twine_function = register
-        twine_args = (files[0], server, None, None, None, '~/.pypirc')
+        twine_args = (files[0], server, None, None, None,
+                      '~/.pypirc', None, None, None)
     elif twine_command == 'upload':
         twine_function = upload
+        # There is currently no stable API for twine upload.
+        # See https://github.com/zestsoftware/zest.releaser/issues/183
+        # It is 'semi-stable'.  It may get new arguments.
+        # def upload(dists, repository, sign, identity, username, password,
+        #            comment, sign_with, config_file, skip_existing,
+        #            cert, client_cert, repository_url)
+        # If you change the call here, you probably need to change
+        # our mock_upload function in tests/test_setup.py.
         twine_args = (files, server, False, None, None, None,
-                      None, 'gpg', '~/.pypirc', False)
+                      None, 'gpg', '~/.pypirc', False,
+                      None, None, None)
     else:
         print(Fore.RED + "Unknown twine command: %s" % twine_command)
         sys.exit(1)


### PR DESCRIPTION
Fixes https://github.com/zestsoftware/zest.releaser/issues/183

Note: this means that there actually is no version of zest.releaser that works with twine 1.7.x. But that's okay.