### PR TITLE
Allow `pypirc` with just a `pypi` section.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,21 @@ Changelog for zest.releaser
 6.8 (unreleased)
 ----------------
 
+- Allow ``.pypirc`` with just a ``pypi`` section.  Previously, we
+  required either a ``[server-login]`` section with a ``username``
+  option, or a ``[distutils]`` section with an ``index-servers`` option.
+  Failing this, we gave a warning about a not properly configured
+  file, and happily continued without uploading anything.  Now if
+  there is something missing from the ``pypirc`` file, we give an
+  error and explicitly ask if you want to continue without uploading.
+  Fixes `issue #199 <https://github.com/zestsoftware/zest.releaser/issues/199>`_.
+
+  Note for developers of extensions for ``zest.releaser``: this
+  removes the ``is_old_pypi_config`` and ``is_new_pypi_config``
+  methods, because they made no sense anymore.  If you were using
+  these, see if you can use the ``distutils_server`` method instead.
+  [maurits]
+
 - Added ``push-changes`` config file option.  Default: yes.  When this
   is false, zest.releaser sets ``no`` as default answer for the
   question if you want to push the changes to the remote.

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -121,10 +121,14 @@ class Releaser(baserelease.Basereleaser):
             result = utils.execute_command(utils.setup_py('bdist_wheel'))
         utils.show_interesting_lines(result)
         if not self.pypiconfig.is_pypi_configured():
-            logger.warn("You must have a properly configured %s file in "
-                        "your home dir to upload to a package index.",
-                        pypi.DIST_CONFIG_FILE)
-            return
+            logger.error(
+                "You must have a properly configured %s file in "
+                "your home dir to upload to a Python package index.",
+                pypi.DIST_CONFIG_FILE)
+            if utils.ask("Do you want to continue without uploading?",
+                         default=False):
+                return
+            sys.exit(1)
 
         # Run extra entry point
         self._run_hooks('before_upload')
@@ -134,11 +138,7 @@ class Releaser(baserelease.Basereleaser):
             os.path.join('dist', filename) for filename in os.listdir('dist')]
 
         # Get servers/repositories.
-        if self.pypiconfig.is_old_pypi_config():
-            servers = ['pypi']
-        else:
-            # The user may have defined other servers to upload to.
-            servers = self.pypiconfig.distutils_servers()
+        servers = self.pypiconfig.distutils_servers()
 
         register = self.pypiconfig.register_package()
         for server in servers:

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -39,10 +39,24 @@ There are two styles of ``.pypirc`` files.  The old one just for pypi:
     [zest.releaser]
     extra-message = [ci skip]
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_old)
-    >>> pypiconfig.is_old_pypi_config()
-    True
-    >>> pypiconfig.is_new_pypi_config()
-    False
+    >>> pypiconfig.distutils_servers()
+    ['pypi']
+
+With ``get_server_config`` we get the settings that we pass to ``twine``:
+
+    >>> from pprint import pprint
+    >>> pprint(pypiconfig.get_server_config('pypi'))
+    {'password': 'asjemenou',
+     'repository_url': 'https://upload.pypi.org/legacy/',
+     'username': 'pipo_de_clown'}
+
+As fallback, the server-login settings and the default url are also
+used when getting the config of a server that does not exist:
+
+    >>> pprint(pypiconfig.get_server_config('nothing'))
+    {'password': 'asjemenou',
+     'repository_url': 'https://upload.pypi.org/legacy/',
+     'username': 'pipo_de_clown'}
 
 And the new format that allows multiple uploads:
 
@@ -72,12 +86,24 @@ And the new format that allows multiple uploads:
     [zest.releaser]
     extra-message = [ci skip]
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_new)
-    >>> pypiconfig.is_old_pypi_config()
-    False
-    >>> pypiconfig.is_new_pypi_config()
-    True
+    >>> pprint(sorted(pypiconfig.distutils_servers()))
+    ['mycompany', 'plone.org', 'pypi']
+    >>> pprint(pypiconfig.get_server_config('mycompany'))
+    {'password': 'password',
+     'repository_url': 'http://my.company/products',
+     'username': 'user'}
+    >>> pprint(pypiconfig.get_server_config('plone.org'))
+    {'password': 'password',
+     'repository_url': 'http://plone.org/products',
+     'username': 'ploneuser'}
+    >>> pprint(pypiconfig.get_server_config('pypi'))
+    {'password': 'password',
+     'repository_url': 'https://upload.pypi.org/legacy/',
+     'username': 'user'}
 
-A file with both is also possible:
+A file with both is also possible.  The old server-login section is
+used to contain the username and password that are shared among
+servers.  Any servers that have no corresponding section are ignored:
 
     >>> pypirc_both = pkg_resources.resource_filename(
     ...     'zest.releaser.tests', 'pypirc_both.txt')
@@ -90,41 +116,45 @@ A file with both is also possible:
     index-servers =
       pypi
       local
+      unknown
     <BLANKLINE>
+    [pypi]
+    password:verysecret
+    <BLANKLINE>
+    [local]
+    repository = http://localhost:8080/test/products
+    username = knight
+    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_both)
+    >>> pprint(sorted(pypiconfig.distutils_servers()))
+    ['local', 'pypi']
+    >>> pprint(pypiconfig.get_server_config('local'))
+    {'password': 'secret',
+     'repository_url': 'http://localhost:8080/test/products',
+     'username': 'knight'}
+    >>> pprint(pypiconfig.get_server_config('pypi'))
+    {'password': 'verysecret',
+     'repository_url': 'https://upload.pypi.org/legacy/',
+     'username': 'bdfl'}
+
+A simple file with just a pypi section is also possible:
+
+    >>> pypirc_simple = pkg_resources.resource_filename(
+    ...     'zest.releaser.tests', 'pypirc_simple.txt')
+    >>> print(open(pypirc_simple).read())
     [pypi]
     username:bdfl
     password:secret
-    <BLANKLINE>
-    [local]
-    repository:http://localhost:8080/test/products
-    username:bdfl
-    password:secret
-    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_both)
-    >>> pypiconfig.is_old_pypi_config()
-    True
-    >>> pypiconfig.is_new_pypi_config()
-    True
-
-Parse the new format again and query a list of distutils servers:
-
-    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_new)
-    >>> from pprint import pprint
+    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_simple)
     >>> pprint(sorted(pypiconfig.distutils_servers()))
-    ['mycompany', 'plone.org', 'pypi']
-
-If we have an old config file, the distutils server list is empty:
-
-    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_old)
-    >>> pypiconfig.distutils_servers()
-    []
-
-And with a file with both an "old" and a "new" set of sections, the pypi entry
-is filtered out of the distutils servers list as that's handled by the "old"
-part:
-
-    >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_both)
-    >>> pprint(sorted(pypiconfig.distutils_servers()))
-    ['local']
+    ['pypi']
+    >>> pprint(pypiconfig.get_server_config('pypi'))
+    {'password': 'secret',
+     'repository_url': 'https://upload.pypi.org/legacy/',
+     'username': 'bdfl'}
+    >>> pprint(pypiconfig.get_server_config('nothing'))
+    {'password': None,
+     'repository_url': 'https://upload.pypi.org/legacy/',
+     'username': None}
 
 
 Asking for making a release or not

--- a/zest/releaser/tests/pypirc_both.txt
+++ b/zest/releaser/tests/pypirc_both.txt
@@ -6,12 +6,11 @@ password:secret
 index-servers =
   pypi
   local
+  unknown
 
 [pypi]
-username:bdfl
-password:secret
+password:verysecret
 
 [local]
-repository:http://localhost:8080/test/products
-username:bdfl
-password:secret
+repository = http://localhost:8080/test/products
+username = knight

--- a/zest/releaser/tests/pypirc_simple.txt
+++ b/zest/releaser/tests/pypirc_simple.txt
@@ -1,0 +1,3 @@
+[pypi]
+username:bdfl
+password:secret


### PR DESCRIPTION
Previously, we required either a `server-login` section with a `username` option, or a `distutils` section with an `index-servers` option.  Failing this, we gave a warning about a not properly configured file, and happily continued without uploading anything. Now if there is something missing from the `pypirc` file, we give an error and explicitly ask if you want to continue without uploading.

Fixes issue #199.

Note for developers of extensions for `zest.releaser`: this removes the `is_old_pypi_config` and `is_new_pypi_config` methods, because they made no sense anymore.  If you were using these, see if you can use the `distutils_server` method instead.