### PR TITLE
Added version-levels and less-zeroes options.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for zest.releaser
 6.8 (unreleased)
 ----------------
 
+- Added ``version-levels`` and ``less-zeroes`` options.
+  This influences the suggested version.  [maurits]
+
 - Allow ``.pypirc`` with just a ``pypi`` section.  Previously, we
   required either a ``[server-login]`` section with a ``username``
   option, or a ``[distutils]`` section with an ``index-servers`` option.

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -103,6 +103,30 @@ push-changes = yes / no
     default answer for the question if you want to push the changes to
     the remote.
 
+less-zeroes = yes / no
+    Default: no.
+    This influences the version suggested by the bumpversion command.
+    When set to true:
+
+    - Instead of 1.3.0 we will suggest 1.3.
+    - Instead of 2.0.0 we will suggest 2.0.
+
+version-levels = a number
+    Default: 0.
+    This influences the version suggested by the postrelease and bumpversion commands.
+    The default of zero means: no preference, so use the length of the current number.
+
+    This means when suggesting a next version after 1.2:
+
+    - with 0 we will suggest 1.3: no change in length
+    - with 1 we will still suggest 1.3, as we will not
+      use this to remove numbers, only to add them
+    - with 2 we will suggest 1.3
+    - with 3 we will suggest 1.2.1
+
+    If the current version number has more levels, we keep them.
+    So with ``version-levels=1`` the next version for 1.2.3.4 will be 1.2.3.5.
+
 
 Per project options
 -------------------

--- a/zest/releaser/bumpversion.py
+++ b/zest/releaser/bumpversion.py
@@ -93,14 +93,20 @@ class BumpVersion(baserelease.Basereleaser):
             else:
                 print("Last tag: {}".format(last_tag_version))
             print("Current version: {}".format(original_version))
+            less_zeroes = self.pypiconfig.less_zeroes()
+            version_levels = self.pypiconfig.version_levels()
             minimum_version = utils.suggest_version(
-                last_tag_version, feature=feature, breaking=breaking)
+                last_tag_version, feature=feature, breaking=breaking,
+                less_zeroes=less_zeroes,
+                levels=version_levels)
             if minimum_version <= original_version:
                 print("No version bump needed.")
                 sys.exit(0)
             # A bump is needed.  Get suggestion for next version.
             suggestion = utils.suggest_version(
-                original_version, feature=feature, breaking=breaking)
+                original_version, feature=feature, breaking=breaking,
+                less_zeroes=less_zeroes,
+                levels=version_levels)
         if not initial:
             new_version = utils.ask_version(
                 "Enter version", default=suggestion)

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -61,7 +61,11 @@ class Postreleaser(baserelease.Basereleaser):
         current = self.vcs.version
         # Clean it up to a non-development version.
         current = utils.cleanup_version(current)
-        suggestion = utils.suggest_version(current)
+        suggestion = utils.suggest_version(
+            current,
+            less_zeroes=self.pypiconfig.less_zeroes(),
+            levels=self.pypiconfig.version_levels(),
+        )
         print("Current version is %s" % current)
         q = "Enter new development version ('.dev0' will be appended)"
         version = utils.ask_version(q, default=suggestion)

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -72,6 +72,8 @@ Mostly for postrelease.  Suggest updated version number.
     '1.1'
     >>> utils.suggest_version('1.9')
     '1.10'
+    >>> utils.suggest_version('1.0.9')
+    '1.0.10'
     >>> utils.suggest_version('1.2.3')
     '1.2.4'
     >>> utils.suggest_version('1.2.3.4')
@@ -80,6 +82,22 @@ Mostly for postrelease.  Suggest updated version number.
     '1.2.3.20'
     >>> utils.suggest_version('1.2a1')
     '1.2a2'
+
+If you prefer major.minor.patch as version, you can influence this with the 'levels' parameter.
+
+    >>> utils.suggest_version('1.2', levels=2)
+    '1.3'
+    >>> utils.suggest_version('1.2', levels=3)
+    '1.2.1'
+    >>> utils.suggest_version('1.2', levels=4)
+    '1.2.0.1'
+
+If the existing number of levels is higher than the requested, we are not going to remove any:
+
+    >>> utils.suggest_version('1.2', levels=1)
+    '1.3'
+    >>> utils.suggest_version('1.2.3.4.5', levels=2)
+    '1.2.3.4.6'
 
 Some corner cases that should not break::
 
@@ -92,6 +110,8 @@ Keep development marker when it is there.
 
     >>> utils.suggest_version('1.0.dev0')
     '1.1.dev0'
+    >>> utils.suggest_version('1.0.dev0', levels=3)
+    '1.0.1.dev0'
 
 Suggest versions for a feature (minor) or breaking (major) release:
 
@@ -99,16 +119,69 @@ Suggest versions for a feature (minor) or breaking (major) release:
     '1.1'
     >>> utils.suggest_version('1.0.1', feature=True)
     '1.1.0'
+    >>> utils.suggest_version('1.0.0.1', feature=True)
+    '1.1.0.0'
     >>> utils.suggest_version('1.0', breaking=True)
     '2.0'
+    >>> utils.suggest_version('1', feature=True)
+    '2'
+    >>> utils.suggest_version('1', breaking=True)
+    '2'
+    >>> utils.suggest_version('1', breaking=True, levels=3)
+    '2.0.0'
     >>> utils.suggest_version('1.0.1', breaking=True)
     '2.0.0'
+
+Prefering less levels than currently in the version number has no effect:
+
+    >>> utils.suggest_version('1.0.1', breaking=True, levels=1)
+    '2.0.0'
+
+Test with markers:
+
     >>> utils.suggest_version('1.0.1.dev0', breaking=True)
     '2.0.0.dev0'
     >>> utils.suggest_version('1.0.1a1', feature=True)
     '1.1.0'
-    >>> utils.suggest_version('1.0.1a1', breaking=True)
+    >>> utils.suggest_version('1.0.1b1', breaking=True)
     '2.0.0'
+
+If you want a feature bump on an alpha, beta, or release candidate, it gets confusing, and we give up:
+
+    >>> utils.suggest_version('1.2rc1', feature=True) is None
+    True
+
+We can prefer less zeroes:
+
+    >>> utils.suggest_version('1.2.3', feature=True, less_zeroes=True)
+    '1.3'
+    >>> utils.suggest_version('1.0.0.0.0', breaking=True, less_zeroes=True)
+    '2.0'
+    >>> utils.suggest_version('1.0.0', breaking=True, less_zeroes=True, levels=5)
+    '2.0'
+
+Without feature or breaking, less_zeroes has no effect, because it
+can only affect zeroes at the end of a version:
+
+    >>> utils.suggest_version('0.0.3', less_zeroes=False)
+    '0.0.4'
+
+Maurits thinks he prefers levels=3 and less_zeroes=True, because this
+hopefully delivers what the Plone Release Team prefers, so let's test
+this combination a bit more:
+
+    >>> utils.suggest_version('1.0', less_zeroes=True, levels=3)
+    '1.0.1'
+    >>> utils.suggest_version('1.0.1', less_zeroes=True, levels=3)
+    '1.0.2'
+    >>> utils.suggest_version('1.0.2', feature=True, less_zeroes=True, levels=3)
+    '1.1'
+    >>> utils.suggest_version('1.1', less_zeroes=True, levels=3)
+    '1.1.1'
+    >>> utils.suggest_version('1.1.1', breaking=True, less_zeroes=True, levels=3)
+    '2.0'
+    >>> utils.suggest_version('1.7.2.1', less_zeroes=True, levels=3)
+    '1.7.2.2'
 
 
 Asking input


### PR DESCRIPTION
This influences the suggested version.  The defaults give the same results as previously. I tested this by copying the `utils.txt` tests from this branch, removing the lines that use the new options, and running them with the code from the master branch.

I myself am going to prefer `less-zeroes = yes` and `version-levels = 3` in my `~/.pypirc`, which gives the results that the Plone Release Team prefers.

The options are documented in `options.rst`, copied here for good measure:

**less-zeroes = yes / no**
Default: no.
This influences the version suggested by the bumpversion command.
When set to true:

- Instead of 1.3.0 we will suggest 1.3.
- Instead of 2.0.0 we will suggest 2.0.

**version-levels = a number**
Default: 0.
This influences the version suggested by the postrelease and bumpversion commands.
The default of zero means: no preference, so use the length of the current number.

This means when suggesting a next version after 1.2:

- with 0 we will suggest 1.3: no change in length
- with 1 we will still suggest 1.3, as we will not
 use this to remove numbers, only to add them
- with 2 we will suggest 1.3
- with 3 we will suggest 1.2.1

If the current version number has more levels, we keep them.
So with ``version-levels=1`` the next version for 1.2.3.4 will be 1.2.3.5.
