### PR TITLE
Override dev marker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for zest.releaser
 6.8 (unreleased)
 ----------------
 
+- Added ``development-marker`` config option.  With this can override
+  the default ``.dev0``.  [drucci]
+
 - Added ``version-levels`` and ``less-zeroes`` options.
   This influences the suggested version.  [maurits]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for zest.releaser
 6.8 (unreleased)
 ----------------
 
+- Added ``version-levels`` and ``less-zeroes`` options.
+  This influences the suggested version.  [maurits]
+
 - Allow ``.pypirc`` with just a ``pypi`` section.  Previously, we
   required either a ``[server-login]`` section with a ``username``
   option, or a ``[distutils]`` section with an ``index-servers`` option.

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -103,6 +103,30 @@ push-changes = yes / no
     default answer for the question if you want to push the changes to
     the remote.
 
+less-zeroes = yes / no
+    Default: no.
+    This influences the version suggested by the bumpversion command.
+    When set to true:
+
+    - Instead of 1.3.0 we will suggest 1.3.
+    - Instead of 2.0.0 we will suggest 2.0.
+
+version-levels = a number
+    Default: 0.
+    This influences the version suggested by the postrelease and bumpversion commands.
+    The default of zero means: no preference, so use the length of the current number.
+
+    This means when suggesting a next version after 1.2:
+
+    - with 0 we will suggest 1.3: no change in length
+    - with 1 we will still suggest 1.3, as we will not
+      use this to remove numbers, only to add them
+    - with 2 we will suggest 1.3
+    - with 3 we will suggest 1.2.1
+
+    If the current version number has more levels, we keep them.
+    So with ``version-levels=1`` the next version for 1.2.3.4 will be 1.2.3.5.
+
 
 Per project options
 -------------------

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -127,6 +127,11 @@ version-levels = a number
     If the current version number has more levels, we keep them.
     So with ``version-levels=1`` the next version for 1.2.3.4 will be 1.2.3.5.
 
+development-marker = a string
+    Default: ``.dev0``
+    This is the development marker.
+    This is what gets appended to the version in postrelease.
+
 
 Per project options
 -------------------

--- a/zest/releaser/bumpversion.py
+++ b/zest/releaser/bumpversion.py
@@ -93,20 +93,21 @@ class BumpVersion(baserelease.Basereleaser):
             else:
                 print("Last tag: {}".format(last_tag_version))
             print("Current version: {}".format(original_version))
-            less_zeroes = self.pypiconfig.less_zeroes()
-            version_levels = self.pypiconfig.version_levels()
+            params = dict(
+                feature=feature,
+                breaking=breaking,
+                less_zeroes=self.pypiconfig.less_zeroes(),
+                levels=self.pypiconfig.version_levels(),
+                dev_marker=self.pypiconfig.development_marker(),
+            )
             minimum_version = utils.suggest_version(
-                last_tag_version, feature=feature, breaking=breaking,
-                less_zeroes=less_zeroes,
-                levels=version_levels)
+                last_tag_version, **params)
             if minimum_version <= original_version:
                 print("No version bump needed.")
                 sys.exit(0)
             # A bump is needed.  Get suggestion for next version.
             suggestion = utils.suggest_version(
-                original_version, feature=feature, breaking=breaking,
-                less_zeroes=less_zeroes,
-                levels=version_levels)
+                original_version, **params)
         if not initial:
             new_version = utils.ask_version(
                 "Enter version", default=suggestion)

--- a/zest/releaser/bumpversion.py
+++ b/zest/releaser/bumpversion.py
@@ -93,14 +93,20 @@ class BumpVersion(baserelease.Basereleaser):
             else:
                 print("Last tag: {}".format(last_tag_version))
             print("Current version: {}".format(original_version))
+            less_zeroes = self.pypiconfig.less_zeroes()
+            version_levels = self.pypiconfig.version_levels()
             minimum_version = utils.suggest_version(
-                last_tag_version, feature=feature, breaking=breaking)
+                last_tag_version, feature=feature, breaking=breaking,
+                less_zeroes=less_zeroes,
+                levels=version_levels)
             if minimum_version <= original_version:
                 print("No version bump needed.")
                 sys.exit(0)
             # A bump is needed.  Get suggestion for next version.
             suggestion = utils.suggest_version(
-                original_version, feature=feature, breaking=breaking)
+                original_version, feature=feature, breaking=breaking,
+                less_zeroes=less_zeroes,
+                levels=version_levels)
         if not initial:
             new_version = utils.ask_version(
                 "Enter version", default=suggestion)

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -61,7 +61,11 @@ class Postreleaser(baserelease.Basereleaser):
         current = self.vcs.version
         # Clean it up to a non-development version.
         current = utils.cleanup_version(current)
-        suggestion = utils.suggest_version(current)
+        suggestion = utils.suggest_version(
+            current,
+            less_zeroes=self.pypiconfig.less_zeroes(),
+            levels=self.pypiconfig.version_levels(),
+        )
         print("Current version is %s" % current)
         q = "Enter new development version ('.dev0' will be appended)"
         version = utils.ask_version(q, default=suggestion)

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -35,12 +35,10 @@ class Postreleaser(baserelease.Basereleaser):
     def __init__(self, vcs=None):
         baserelease.Basereleaser.__init__(self, vcs=vcs)
         # Prepare some defaults for potential overriding.
-        development_marker = self.setup_cfg.development_marker()
-
         self.data.update(dict(
             commit_msg=COMMIT_MSG,
             dev_version_template=DEV_VERSION_TEMPLATE,
-            development_marker=development_marker,
+            development_marker=self.pypiconfig.development_marker(),
             history_header=HISTORY_HEADER,
         ))
 

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -67,6 +67,7 @@ class Postreleaser(baserelease.Basereleaser):
             current,
             less_zeroes=self.pypiconfig.less_zeroes(),
             levels=self.pypiconfig.version_levels(),
+            dev_marker=self.pypiconfig.development_marker(),
         )
         print("Current version is %s" % current)
         q = ("Enter new development version "

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 HISTORY_HEADER = '%(new_version)s (unreleased)'
 COMMIT_MSG = 'Back to development: %(new_version)s'
-DEV_VERSION_TEMPLATE = '%(new_version)s.dev0'
+DEV_VERSION_TEMPLATE = '%(new_version)s%(development_marker)s'
 
 # Documentation for self.data.  You get runtime warnings when something is in
 # self.data that is not in this list.  Embarrasment-driven documentation!
@@ -20,6 +20,7 @@ DATA = baserelease.DATA.copy()
 DATA.update({
     'dev_version': 'New version with development marker (so 1.1.dev0)',
     'dev_version_template': 'Template for development version number',
+    'development_marker': 'String to be appended to version after postrelease',
     'new_version': 'New version, without development marker (so 1.1)',
 })
 
@@ -34,9 +35,12 @@ class Postreleaser(baserelease.Basereleaser):
     def __init__(self, vcs=None):
         baserelease.Basereleaser.__init__(self, vcs=vcs)
         # Prepare some defaults for potential overriding.
+        development_marker = self.setup_cfg.development_marker()
+
         self.data.update(dict(
             commit_msg=COMMIT_MSG,
             dev_version_template=DEV_VERSION_TEMPLATE,
+            development_marker=development_marker,
             history_header=HISTORY_HEADER,
         ))
 
@@ -67,7 +71,8 @@ class Postreleaser(baserelease.Basereleaser):
             levels=self.pypiconfig.version_levels(),
         )
         print("Current version is %s" % current)
-        q = "Enter new development version ('.dev0' will be appended)"
+        q = ("Enter new development version "
+             "('%(development_marker)s' will be appended)" % self.data)
         version = utils.ask_version(q, default=suggestion)
         if not version:
             version = suggestion

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -51,25 +51,6 @@ class SetupConfig(object):
         with codecs.open(self.config_filename, 'r', 'utf8') as fp:
             self.config.readfp(fp)
 
-    def development_marker(self):
-        """Return development marker to be appended in postrelease
-
-        Override the default ``.dev0`` in setup.cfg using
-        a ``development-marker`` option::
-
-            [zest.releaser]
-            development-marker = .dev1
-
-        Returns default of `.dev0` when nothing has been configured.
-
-        """
-        try:
-            result = self.config.get('zest.releaser',
-                                     'development-marker')
-        except (NoSectionError, NoOptionError, ValueError):
-            result = ".dev0"
-        return result
-
     def has_bad_commands(self):
         if self.config is None:
             return False
@@ -325,6 +306,27 @@ class PypiConfig(object):
         The default when this option has not been set is False.
         """
         return self._get_boolean('zest.releaser', 'no-input')
+
+    def development_marker(self):
+        """Return development marker to be appended in postrelease.
+
+        Override the default ``.dev0`` in setup.cfg using
+        a ``development-marker`` option::
+
+            [zest.releaser]
+            development-marker = .dev1
+
+        Returns default of ``.dev0`` when nothing has been configured.
+        """
+        default = '.dev0'
+        if self.config is None:
+            return default
+        try:
+            result = self.config.get(
+                'zest.releaser', 'development-marker')
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
 
     def push_changes(self):
         """Return whether the user wants to push the changes to the remote.

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -51,6 +51,25 @@ class SetupConfig(object):
         with codecs.open(self.config_filename, 'r', 'utf8') as fp:
             self.config.readfp(fp)
 
+    def development_marker(self):
+        """Return development marker to be appended in postrelease
+
+        Override the default ``.dev0`` in setup.cfg using
+        a ``development-marker`` option::
+
+            [zest.releaser]
+            development-marker = .dev1
+
+        Returns default of `.dev0` when nothing has been configured.
+
+        """
+        try:
+            result = self.config.get('zest.releaser',
+                                     'development-marker')
+        except (NoSectionError, NoOptionError, ValueError):
+            result = ".dev0"
+        return result
+
     def has_bad_commands(self):
         if self.config is None:
             return False

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -106,12 +106,14 @@ Some corner cases that should not break::
     >>> utils.suggest_version('a.1')
     'a.2'
 
-Keep development marker when it is there.
+Keep development marker when it is there, but reset any version part of that marker.
 
     >>> utils.suggest_version('1.0.dev0')
     '1.1.dev0'
-    >>> utils.suggest_version('1.0.dev0', levels=3)
+    >>> utils.suggest_version('1.0.dev6', levels=3)
     '1.0.1.dev0'
+    >>> utils.suggest_version('1.0-snapshot123', dev_marker='-snapshot')
+    '1.1-snapshot'
 
 Suggest versions for a feature (minor) or breaking (major) release:
 

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -72,6 +72,8 @@ Mostly for postrelease.  Suggest updated version number.
     '1.1'
     >>> utils.suggest_version('1.9')
     '1.10'
+    >>> utils.suggest_version('1.0.9')
+    '1.0.10'
     >>> utils.suggest_version('1.2.3')
     '1.2.4'
     >>> utils.suggest_version('1.2.3.4')
@@ -80,6 +82,22 @@ Mostly for postrelease.  Suggest updated version number.
     '1.2.3.20'
     >>> utils.suggest_version('1.2a1')
     '1.2a2'
+
+If you prefer major.minor.patch as version, you can influence this with the 'levels' parameter.
+
+    >>> utils.suggest_version('1.2', levels=2)
+    '1.3'
+    >>> utils.suggest_version('1.2', levels=3)
+    '1.2.1'
+    >>> utils.suggest_version('1.2', levels=4)
+    '1.2.0.1'
+
+If the existing number of levels is higher than the requested, we are not going to remove any:
+
+    >>> utils.suggest_version('1.2', levels=1)
+    '1.3'
+    >>> utils.suggest_version('1.2.3.4.5', levels=2)
+    '1.2.3.4.6'
 
 Some corner cases that should not break::
 
@@ -92,6 +110,8 @@ Keep development marker when it is there.
 
     >>> utils.suggest_version('1.0.dev0')
     '1.1.dev0'
+    >>> utils.suggest_version('1.0.dev0', levels=3)
+    '1.0.1.dev0'
 
 Suggest versions for a feature (minor) or breaking (major) release:
 
@@ -99,16 +119,69 @@ Suggest versions for a feature (minor) or breaking (major) release:
     '1.1'
     >>> utils.suggest_version('1.0.1', feature=True)
     '1.1.0'
+    >>> utils.suggest_version('1.0.0.1', feature=True)
+    '1.1.0.0'
     >>> utils.suggest_version('1.0', breaking=True)
     '2.0'
+    >>> utils.suggest_version('1', feature=True)
+    '2'
+    >>> utils.suggest_version('1', breaking=True)
+    '2'
+    >>> utils.suggest_version('1', breaking=True, levels=3)
+    '2.0.0'
     >>> utils.suggest_version('1.0.1', breaking=True)
     '2.0.0'
+
+Prefering less levels than currently in the version number has no effect:
+
+    >>> utils.suggest_version('1.0.1', breaking=True, levels=1)
+    '2.0.0'
+
+Test with markers:
+
     >>> utils.suggest_version('1.0.1.dev0', breaking=True)
     '2.0.0.dev0'
     >>> utils.suggest_version('1.0.1a1', feature=True)
     '1.1.0'
-    >>> utils.suggest_version('1.0.1a1', breaking=True)
+    >>> utils.suggest_version('1.0.1b1', breaking=True)
     '2.0.0'
+
+If you want a feature bump on an alpha, beta, or release candidate, it gets confusing, and we give up:
+
+    >>> utils.suggest_version('1.2rc1', feature=True) is None
+    True
+
+We can prefer less zeroes:
+
+    >>> utils.suggest_version('1.2.3', feature=True, less_zeroes=True)
+    '1.3'
+    >>> utils.suggest_version('1.0.0.0.0', breaking=True, less_zeroes=True)
+    '2.0'
+    >>> utils.suggest_version('1.0.0', breaking=True, less_zeroes=True, levels=5)
+    '2.0'
+
+Without feature or breaking, less_zeroes has no effect, because it
+can only affect zeroes at the end of a version:
+
+    >>> utils.suggest_version('0.0.3', less_zeroes=False)
+    '0.0.4'
+
+Maurits thinks he prefers levels=3 and less_zeroes=True, because this
+hopefully delivers what the Plone Release Team prefers, so let's test
+this combination a bit more:
+
+    >>> utils.suggest_version('1.0', less_zeroes=True, levels=3)
+    '1.0.1'
+    >>> utils.suggest_version('1.0.1', less_zeroes=True, levels=3)
+    '1.0.2'
+    >>> utils.suggest_version('1.0.2', feature=True, less_zeroes=True, levels=3)
+    '1.1'
+    >>> utils.suggest_version('1.1', less_zeroes=True, levels=3)
+    '1.1.1'
+    >>> utils.suggest_version('1.1.1', breaking=True, less_zeroes=True, levels=3)
+    '2.0'
+    >>> utils.suggest_version('1.7.2.1', less_zeroes=True, levels=3)
+    '1.7.2.2'
 
 
 Asking input

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -175,8 +175,23 @@ def cleanup_version(version):
     return version
 
 
+def strip_last_number(value):
+    """Remove last number from a value.
+
+    This is mostly for markers like ``.dev0``, where this would
+    return ``.dev``.
+    """
+    if not value:
+        return value
+    match = re.search('\d+$', value)
+    if not match:
+        return value
+    return value[:-len(match.group())]
+
+
 def suggest_version(current, feature=False, breaking=False,
-                    less_zeroes=False, levels=0):
+                    less_zeroes=False, levels=0,
+                    dev_marker='.dev0'):
     """Suggest new version.
 
     Try to make sure that the suggestion for next version after
@@ -193,9 +208,11 @@ def suggest_version(current, feature=False, breaking=False,
         print('Cannot have both breaking and feature in suggest_version.')
         sys.exit(1)
     dev = ''
-    if '.dev' in current:
-        index = current.find('.dev')
-        dev = current[index:]
+    base_dev_marker = strip_last_number(dev_marker)
+    if base_dev_marker in current:
+        index = current.find(base_dev_marker)
+        # Put the standard development marker back at the end.
+        dev = dev_marker
         current = current[:index]
     # Split in first and last part, where last part is one integer and the
     # first part can contain more integers plus dots.


### PR DESCRIPTION
This builds on pull request #204 because it would otherwise cause merge conflicts.

This replaces pull request #176. I did some minor changes and addressed the [comment by @drucci](https://github.com/zestsoftware/zest.releaser/pull/176#issuecomment-219068856) about a change needed in `suggest_version`.