### PR TITLE
Add tag formatter in the config

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -132,6 +132,11 @@ development-marker = a string
     This is the development marker.
     This is what gets appended to the version in postrelease.
 
+tag-format = a string
+    Default: ``%(version)s``
+    This is a formatter that change the name of the tag.
+    It needs to contain ``%(version)s``
+
 
 Per project options
 -------------------

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -134,7 +134,7 @@ development-marker = a string
 
 tag-format = a string
     Default: ``%(version)s``
-    This is a formatter that change the name of the tag.
+    This is a formatter that changes the name of the tag.
     It needs to contain ``%(version)s``
 
 

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -426,13 +426,12 @@ class PypiConfig(object):
         try:
             result = self.config.get(
                 'zest.releaser', 'tag-format')
-            #test the formater
-            if not re.search('%\(version\)s', result):
-                print('%(version)s needs to be part of the string formater')
-                sys.exit(1)
         except (NoSectionError, NoOptionError, ValueError):
             return default
-
+        # test the formatter
+        if not re.search('%\(version\)s', result):
+            print('%(version)s needs to be part of the string formatter')
+            sys.exit(1)
         return result
 
     def _get_boolean(self, section, key, default=False):

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -407,6 +407,31 @@ class PypiConfig(object):
             return default
         return result
 
+    def tag_format(self):
+        """Return the string formating the tag name in the release.
+
+        Override the default ``%(version)`` in setup.cfg using
+        a ``tag-format`` option::
+
+            [zest.releaser]
+            tag-format = v%(version)s
+
+        Returns default of ``%(version)s`` when nothing has been configured.
+        """
+        default = '%(version)s'
+        if self.config is None:
+            return default
+        try:
+            result = self.config.get(
+                'zest.releaser', 'tag-format')
+            try:
+                '%(version)s'%({'version':''})
+            except KeyError:
+                raise ValueError('version needs to be part of the string formater use default')
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
+
     def _get_boolean(self, section, key, default=False):
         """Get a boolean from the config.
 

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -4,6 +4,7 @@ import codecs
 import logging
 import os
 import sys
+import re
 
 import pkg_resources
 from six.moves.configparser import ConfigParser
@@ -426,13 +427,12 @@ class PypiConfig(object):
             result = self.config.get(
                 'zest.releaser', 'tag-format')
             #test the formater
-            result % ({'version':''})
-
+            if not re.search('%\(version\)s', result):
+                print('%(version)s needs to be part of the string formater')
+                sys.exit(1)
         except (NoSectionError, NoOptionError, ValueError):
             return default
-        except KeyError:
-            print('%(version)s needs to be part of the string formater')
-            sys.exit(1)
+
         return result
 
     def _get_boolean(self, section, key, default=False):

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import codecs
 import logging
 import os
+import sys
 
 import pkg_resources
 from six.moves.configparser import ConfigParser
@@ -322,7 +323,7 @@ class PypiConfig(object):
     def development_marker(self):
         """Return development marker to be appended in postrelease.
 
-        Override the default ``.dev0`` in setup.cfg using
+        Override the default ``.dev0`` in ~/.pypirc or setup.cfg using
         a ``development-marker`` option::
 
             [zest.releaser]
@@ -408,9 +409,9 @@ class PypiConfig(object):
         return result
 
     def tag_format(self):
-        """Return the string formating the tag name in the release.
+        """Return the string format for the tag name used in the release.
 
-        Override the default ``%(version)`` in setup.cfg using
+        Override the default ``%(version)s`` in ~/.pypirc or setup.cfg using
         a ``tag-format`` option::
 
             [zest.releaser]
@@ -424,12 +425,14 @@ class PypiConfig(object):
         try:
             result = self.config.get(
                 'zest.releaser', 'tag-format')
-            try:
-                '%(version)s'%({'version':''})
-            except KeyError:
-                raise ValueError('version needs to be part of the string formater use default')
+            #test the formater
+            result % ({'version':''})
+
         except (NoSectionError, NoOptionError, ValueError):
             return default
+        except KeyError:
+            print('%(version)s needs to be part of the string formater')
+            sys.exit(1)
         return result
 
     def _get_boolean(self, section, key, default=False):

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -430,7 +430,7 @@ class PypiConfig(object):
             return default
         # test the formatter
         if not re.search('%\(version\)s', result):
-            print('%(version)s needs to be part of the string formatter')
+            print("%%(version)s needs to be part of 'tag-format': %s" % result)
             sys.exit(1)
         return result
 

--- a/zest/releaser/tests/release.txt
+++ b/zest/releaser/tests/release.txt
@@ -69,8 +69,7 @@ We check if a tag already exists.  First set the version to 0.1:
 
     >>> releaser = release.Releaser()
     >>> releaser.vcs.version = '0.1'
-    >>> releaser._grab_version()
-    >>> releaser._check_if_tag_already_exists()
+    >>> releaser.prepare()
     >>> releaser.data['tag_already_exists']
     False
 
@@ -108,6 +107,7 @@ tag command:
     >>> releaser = release.Releaser()
     >>> releaser.data['tag_already_exists'] = False
     >>> releaser.data['version'] = '0.1'
+    >>> releaser.data['tag'] = '0.1'
     >>> utils.test_answer_book.set_answers(['n'])
     >>> releaser._make_tag()
     Traceback (most recent call last):

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -170,12 +170,12 @@ class BaseVersionControl(object):
         if history:
             return history
 
-    def tag_exists(self, version):
+    def tag_exists(self, tag_name):
         """Check if a tag has already been created with the name of the
         version.
         """
         for tag in self.available_tags():
-            if tag == version:
+            if tag == tag_name:
                 return True
         return False
 


### PR DESCRIPTION
This PR adds a tag formatter in the `.pypirc` options  and should resolve #157
Do let me know if I missed something and am happy to change it.
