### PR TITLE
Support uppercase `VERSION = ` in setup.py, fixes #216

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog for zest.releaser
 6.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Corner case fix: a top-level ``version = 1.0`` in your ``setup.py`` is now
+  also allowed to be in uppercase, like ``VERSION = 1.0``.
+  This fixes `issue 216
+  <https://github.com/zestsoftware/zest.releaser/issues/216>`_.
+  [reinout]
 
 
 6.9 (2017-02-17)

--- a/zest/releaser/tests/vcs.txt
+++ b/zest/releaser/tests/vcs.txt
@@ -229,3 +229,19 @@ Version files can also be called ``version.rst`` (or .md or so) instead of ``ver
     >>> writeto('version.rst', '25.0')
     >>> checkout.get_version_txt_version()
     '25.0'
+
+Setup.py with an uppercase VERSION:
+
+    >>> uppercaseversionproject = os.path.join(tempdir, 'uvp')
+    >>> os.mkdir(uppercaseversionproject)
+    >>> os.chdir(uppercaseversionproject)
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "VERSION = '1.0'",
+    ...     "setup(name='urgh', version=VERSION)"]
+    >>> writeto('setup.py', '\n'.join(lines))
+    >>> checkout.version = '1.2'
+    >>> print(open('setup.py').read())
+    from setuptools import setup
+    VERSION = '1.2'
+    setup(name='urgh', version=VERSION)

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -20,7 +20,7 @@ version\s*=\s*   # 'version =  ' with possible whitespace
 """, re.VERBOSE)
 UPPERCASE_VERSION_PATTERN = re.compile(r"""
 ^                # Start of line
-VERSION\s*=\s*   # 'version =  ' with possible whitespace
+VERSION\s*=\s*   # 'VERSION =  ' with possible whitespace
 ['"]             # String literal begins
 \d               # Some digit, start of version.
 """, re.VERBOSE)

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -18,6 +18,12 @@ version\s*=\s*   # 'version =  ' with possible whitespace
 ['"]             # String literal begins
 \d               # Some digit, start of version.
 """, re.VERBOSE)
+UPPERCASE_VERSION_PATTERN = re.compile(r"""
+^                # Start of line
+VERSION\s*=\s*   # 'version =  ' with possible whitespace
+['"]             # String literal begins
+\d               # Some digit, start of version.
+""", re.VERBOSE)
 
 UNDERSCORED_VERSION_PATTERN = re.compile(r"""
 ^                    # Start of line
@@ -249,6 +255,16 @@ class BaseVersionControl(object):
                     indentation = line.split('version')[0]
                     # Note: no spaces around the '='.
                     good_version = indentation + "version='%s'," % version
+                setup_lines[line_number] = good_version
+                utils.write_text_file(
+                    'setup.py', '\n'.join(setup_lines), encoding)
+                logger.info("Set setup.py's version to %r", version)
+                return
+            if UPPERCASE_VERSION_PATTERN.search(line):
+                # This one only occurs in the first column, so no need to
+                # handle indentation.
+                logger.debug("Matching version line found: %r", line)
+                good_version = good_version.upper()
                 setup_lines[line_number] = good_version
                 utils.write_text_file(
                     'setup.py', '\n'.join(setup_lines), encoding)


### PR DESCRIPTION
This fixes #216 