### PR TITLE
Escape git clone path so it works when windows drives are mounted

### DIFF
--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -49,7 +49,7 @@ class Git(BaseVersionControl):
         temp = tempfile.mkdtemp(prefix=prefix)
         cwd = os.getcwd()
         os.chdir(temp)
-        cmd = 'git clone --depth 1 file://%s %s' % (self.reporoot, 'gitclone')
+        cmd = 'git clone --depth 1 "file://%s" %s' % (self.reporoot, 'gitclone')
         logger.debug(execute_command(cmd))
         clonedir = os.path.join(temp, 'gitclone')
         os.chdir(clonedir)


### PR DESCRIPTION
I use the linux subsystem in windows all the time. It maps things to my windows username, which in this case happens to be "/mnt/c/Users/Gavin Mogan" so when the git clone happens, it thinks its multiple parameters.

Quote the path so it doesn't care about spaces.