### PR TITLE
Add skip-missing-hooks option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog for zest.releaser
 6.12.5 (unreleased)
 -------------------
 
-- Add ``skip-missing-hooks`` option in ``setup.cfg`` to control whether the
-  release process should should fail when specified hooks cannot be imported.
+- Release process will now fail when specified hooks cannot be imported.
+  (`PR #236 <https://github.com/zestsoftware/zest.releaser/pulls/236>`_)
 
 
 6.12.4 (2017-08-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog for zest.releaser
 6.12.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add ``skip-missing-hooks`` option in ``setup.cfg`` to control whether the
+  release process should should fail when specified hooks cannot be imported.
 
 
 6.12.4 (2017-08-30)

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -150,11 +150,6 @@ date-format = a string
     Note: the % signs should be doubled for compatibility with other tools
     (i.e. pip) that parse setup.cfg using the interpolating ConfigParser.
 
-skip-missing-hooks = yes / no
-    Default: yes
-    When set to ``no``, the release process will fail if a specified hook
-    cannot be imported.
-
 
 Per project options
 -------------------

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -150,6 +150,10 @@ date-format = a string
     Note: the % signs should be doubled for compatibility with other tools
     (i.e. pip) that parse setup.cfg using the interpolating ConfigParser.
 
+skip-missing-hooks = yes / no
+    Default: yes
+    When set to ``no``, the release process will fail if a specified hook
+    cannot be imported.
 
 
 Per project options

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -599,8 +599,10 @@ def run_hooks(setup_cfg, which_releaser, when, data):
 
         # Hooks that can't be imported are skipped, unless the
         # ``skip_missing_hooks`` option is set to False.
-        skip_missing = config.getboolean('zest.releaser', 'skip_missing_hooks',
-                                         fallback='yes')
+        skip_missing = True
+        if config.has_option('zest.releaser', 'skip_missing_hooks'):
+            skip_missing = config.getboolean('zest.releaser',
+                                             'skip_missing_hooks')
 
         # The following code is adapted from the 'packaging' package being
         # developed for Python's stdlib:

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -597,6 +597,11 @@ def run_hooks(setup_cfg, which_releaser, when, data):
         hook_names = config.get('zest.releaser', hook_group).split()
         hooks = []
 
+        # Hooks that can't be imported are skipped, unless the
+        # ``skip_missing_hooks`` option is set to False.
+        skip_missing = config.getboolean('zest.releaser', 'skip_missing_hooks',
+                                         fallback='yes')
+
         # The following code is adapted from the 'packaging' package being
         # developed for Python's stdlib:
 
@@ -619,6 +624,8 @@ def run_hooks(setup_cfg, which_releaser, when, data):
                 try:
                     hooks.append(resolve_name(hook_name))
                 except ImportError as e:
+                    if not skip_missing:
+                        raise
                     logger.warning('cannot find %s hook: %s; skipping...',
                                    hook_name, e.args[0])
             for hook in hooks:

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -597,13 +597,6 @@ def run_hooks(setup_cfg, which_releaser, when, data):
         hook_names = config.get('zest.releaser', hook_group).split()
         hooks = []
 
-        # Hooks that can't be imported are skipped, unless the
-        # ``skip_missing_hooks`` option is set to False.
-        skip_missing = True
-        if config.has_option('zest.releaser', 'skip_missing_hooks'):
-            skip_missing = config.getboolean('zest.releaser',
-                                             'skip_missing_hooks')
-
         # The following code is adapted from the 'packaging' package being
         # developed for Python's stdlib:
 
@@ -623,13 +616,9 @@ def run_hooks(setup_cfg, which_releaser, when, data):
 
         try:
             for hook_name in hook_names:
-                try:
-                    hooks.append(resolve_name(hook_name))
-                except ImportError as e:
-                    if not skip_missing:
-                        raise
-                    logger.warning('cannot find %s hook: %s; skipping...',
-                                   hook_name, e.args[0])
+                # Resolve the hook or fail with ImportError.
+                hooks.append(resolve_name(hook_name))
+
             for hook in hooks:
                 hook(data)
         finally:


### PR DESCRIPTION
Hi there!

We have a use case where we really don't want the hooks to be skipped when they cannot be imported.

So I added an option, with current behaviour as default :)

I'm kinda puzzled with the way I should test this, I would be grateful if you had some insights about the best way to do it!

Thanks, and also thanks for this awesome tool ;) 



