### PR TITLE
Add option ``tag-signing``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for zest.releaser
 6.12.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for signing tags (option ``tag-signing``). [htgoebel]
 
 
 6.12.5 (2017-09-25)

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -142,6 +142,13 @@ tag-format = a string
     It needs to contain ``{version}``.
     For backward compatibility, it can contain ``%(version)s`` instead.
 
+tag-signing = yes / no
+    Default: no.
+    When set to true, tags are signed using the signing feature of the
+    respective vcs. Currently tag-signing is only supported for git.
+    Note: When you enable it, everyone releasing the project is
+    required to have git tag signing set up correctly.
+
 date-format = a string
     Default: ``%%Y-%%m-%%d``
     This is the format string for the release date to be mentioned in the

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [zest.releaser]
 create-wheel = yes
 extra-message = [ci skip]
+tag-signing = yes
 
 [check-manifest]
 ignore =

--- a/zest/releaser/bzr.py
+++ b/zest/releaser/bzr.py
@@ -53,7 +53,11 @@ class Bzr(BaseVersionControl):
     def cmd_log_since_tag(self, version):
         return "bzr log -r tag:%s..-1" % version
 
-    def cmd_create_tag(self, version):
+    def cmd_create_tag(self, version, sign=False):
+        if sign:
+            logger.error("bzr does not support signing tags, sorry. "
+                         "Please check your configuration in 'setup.cfg'.")
+            sys.exit(20)
         return 'bzr tag %s' % version
 
     def cmd_checkout_from_tag(self, version, checkout_dir):

--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -78,9 +78,11 @@ class Git(BaseVersionControl):
         """
         return "git log %s..HEAD" % version
 
-    def cmd_create_tag(self, version):
+    def cmd_create_tag(self, version, sign=False):
         msg = "Tagging %s" % (version,)
         cmd = 'git tag %s -m "%s"' % (version, msg)
+        if sign:
+            cmd += " --sign"
         if os.path.isdir('.git/svn'):
             print("\nEXPERIMENTAL support for git-svn tagging!\n")
             with open('.git/HEAD') as f:

--- a/zest/releaser/hg.py
+++ b/zest/releaser/hg.py
@@ -64,7 +64,12 @@ class Hg(BaseVersionControl):
         current_revision = current_revision.rstrip('+')
         return "hg log -r %s -r %s" % (version, current_revision)
 
-    def cmd_create_tag(self, version):
+    def cmd_create_tag(self, version, sign=False):
+        if sign:
+            logger.error(
+                "Signing tags with mercurial is not yet implemented, sorry. "
+                "Please check your configuration in 'setup.cfg'.")
+            sys.exit(21)
         # Note: place the '-m' before the argument for hg 1.1 support.
         return 'hg tag -m "Tagging %s" %s' % (version, version)
 

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -462,6 +462,24 @@ class PypiConfig(object):
         print("{version} needs to be part of 'tag-format': %s" % fmt)
         sys.exit(1)
 
+    def tag_signing(self):
+        """Return whether the tag should be signed.
+
+        Configure it in ~/.pypirc or setup.cfg using a ``tag-signing`` option::
+
+            [zest.releaser]
+            tag-signing = yes
+
+        ``tag-signing`` must contain exaclty one word which will be
+        converted to a boolean. Currently are accepted (case
+        insensitively): 0, false, no, off for False, and 1, true, yes,
+        on for True).
+
+        The default when this option has not been set is False.
+
+        """
+        return self._get_boolean('zest.releaser', 'tag-signing', default=False)
+
     def date_format(self):
         """Return the string format for the date used in the changelog.
 

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -31,6 +31,7 @@ DATA.update({
     checkout is done.''',
     'version': "Version we're releasing",
     'tag': "Tag we're releasing",
+    'tag-signing': "Sign tag using gpg or pgp",
 })
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,7 @@ class Releaser(baserelease.Basereleaser):
         """Collect some data needed for releasing"""
         self._grab_version()
         self.data['tag'] = self.pypiconfig.tag_format(self.data['version'])
+        self.data['tag-signing'] = self.pypiconfig.tag_signing()
         self._check_if_tag_already_exists()
 
     def execute(self):
@@ -90,7 +92,7 @@ class Releaser(baserelease.Basereleaser):
         tag = self.data['tag']
         if self.data['tag_already_exists']:
             return
-        cmds = self.vcs.cmd_create_tag(tag)
+        cmds = self.vcs.cmd_create_tag(tag, self.data['tag-signing'])
         if not isinstance(cmds, list):
             cmds = [cmds]
         if len(cmds) == 1:

--- a/zest/releaser/svn.py
+++ b/zest/releaser/svn.py
@@ -183,7 +183,11 @@ class Subversion(BaseVersionControl):
             sys.exit(1)
         return "svn --non-interactive log -r%s:HEAD %s" % (revision, url)
 
-    def cmd_create_tag(self, version):
+    def cmd_create_tag(self, version, sign=False):
+        if sign:
+            logger.error("svn does not support signing tags, sorry. "
+                         "Please check your configuration in 'setup.cfg'.")
+            sys.exit(20)
         url = self._branch_url_from_svn()
         tag_url = self.tag_url(version)
         return 'svn cp --non-interactive %s %s -m "Tagging %s"' % (

--- a/zest/releaser/tests/release.txt
+++ b/zest/releaser/tests/release.txt
@@ -108,6 +108,7 @@ tag command:
     >>> releaser.data['tag_already_exists'] = False
     >>> releaser.data['version'] = '0.1'
     >>> releaser.data['tag'] = '0.1'
+    >>> releaser.data['tag-signing'] = False
     >>> utils.test_answer_book.set_answers(['n'])
     >>> releaser._make_tag()
     Traceback (most recent call last):

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -338,7 +338,7 @@ class BaseVersionControl(object):
         """
         raise NotImplementedError()
 
-    def cmd_create_tag(self, version):
+    def cmd_create_tag(self, version, sign=False):
         "Create a tag from a version name."
         raise NotImplementedError()
 


### PR DESCRIPTION
This does not include test-cases, since these would require interaction for the actually gpg-signing.

Closes #152, albeit this only implements tag-signing. If somebody wants to sign every commit, this ought to be done in the VCS' configuration anyway.