### PR TITLE
Use list of arguments for execute_command, not a string.

### DIFF
--- a/zest/releaser/bzr.py
+++ b/zest/releaser/bzr.py
@@ -26,7 +26,7 @@ class Bzr(BaseVersionControl):
         return dir_name
 
     def available_tags(self):
-        tag_info = execute_command('bzr tags')
+        tag_info = execute_command(['bzr', 'tags'])
         tags = [line[:line.find(' ')] for line in tag_info.split('\n')]
         tags = [tag for tag in tags if tag]
         logger.debug("Available tags: %r", tags)
@@ -42,28 +42,29 @@ class Bzr(BaseVersionControl):
         return version
 
     def cmd_diff(self):
-        return 'bzr diff'
+        return ['bzr', 'diff']
 
     def cmd_commit(self, message):
-        return 'bzr commit -v -m "%s"' % message
+        return ['bzr', 'commit', '-v', '-m', message]
 
     def cmd_diff_last_commit_against_tag(self, version):
-        return "bzr diff -r tag:%s..-1" % version
+        return ["bzr", "diff", "-r", "tag:%s..-1" % version]
 
     def cmd_log_since_tag(self, version):
-        return "bzr log -r tag:%s..-1" % version
+        return ["bzr", "log", "-r", "tag:%s..-1" % version]
 
     def cmd_create_tag(self, version, sign=False):
         if sign:
             logger.error("bzr does not support signing tags, sorry. "
                          "Please check your configuration in 'setup.cfg'.")
             sys.exit(20)
-        return 'bzr tag %s' % version
+        return ["bzr", "tag", version]
 
     def cmd_checkout_from_tag(self, version, checkout_dir):
         source = self.reporoot
         target = checkout_dir
-        return 'bzr checkout -r tag:%s %s %s' % (version, source, target)
+        return ["bzr", "checkout", "-r", "tag:%s" % version,
+                source, target]
 
     def is_clean_checkout(self):
         """Is this a clean checkout?
@@ -77,11 +78,11 @@ class Bzr(BaseVersionControl):
         status' and see what we get.
         """
         # Check for changes to versioned files.
-        if execute_command('bzr status --versioned'):
+        if execute_command(['bzr', 'status', '--versioned']):
             # Local changes.
             return False
         return True
 
     def list_files(self):
         """List files in version control."""
-        return execute_command('bzr ls --recursive').splitlines()
+        return execute_command(['bzr', 'ls', '--recursive']).splitlines()

--- a/zest/releaser/hg.py
+++ b/zest/releaser/hg.py
@@ -28,7 +28,7 @@ class Hg(BaseVersionControl):
         return dir_name
 
     def available_tags(self):
-        tag_info = execute_command('hg tags')
+        tag_info = execute_command(['hg', 'tags'])
         tags = [line[:line.find(' ')] for line in tag_info.split('\n')]
         tags = [tag for tag in tags if tag]
         tags.remove('tip')  # Not functional for us
@@ -45,24 +45,24 @@ class Hg(BaseVersionControl):
         return version
 
     def cmd_diff(self):
-        return 'hg diff'
+        return ['hg', 'diff']
 
     def cmd_commit(self, message):
-        return 'hg commit -v -m "%s"' % message
+        return ['hg', 'commit', '-v', '-m', message]
 
     def cmd_diff_last_commit_against_tag(self, version):
-        current_revision = execute_command('hg identify')
+        current_revision = execute_command(['hg', 'identify'])
         current_revision = current_revision.split(' ')[0]
         # + at the end of the revision denotes uncommitted changes
         current_revision = current_revision.rstrip('+')
-        return "hg diff -r %s -r %s" % (version, current_revision)
+        return ['hg', 'diff', '-r', version, '-r', current_revision]
 
     def cmd_log_since_tag(self, version):
-        current_revision = execute_command('hg identify')
+        current_revision = execute_command(['hg', 'identify'])
         current_revision = current_revision.split(' ')[0]
         # + at the end of the revision denotes uncommitted changes
         current_revision = current_revision.rstrip('+')
-        return "hg log -r %s -r %s" % (version, current_revision)
+        return ['hg', 'log', '-r', version, '-r', current_revision]
 
     def cmd_create_tag(self, version, sign=False):
         if sign:
@@ -71,12 +71,12 @@ class Hg(BaseVersionControl):
                 "Please check your configuration in 'setup.cfg'.")
             sys.exit(21)
         # Note: place the '-m' before the argument for hg 1.1 support.
-        return 'hg tag -m "Tagging %s" %s' % (version, version)
+        return ['hg', 'tag', '-m', 'Tagging %s' % version, version]
 
     def cmd_checkout_from_tag(self, version, checkout_dir):
         source = self.reporoot
         target = checkout_dir
-        return 'hg clone -r %s %s %s' % (version, source, target)
+        return ['hg', 'clone', '-r', version, source, target]
 
     def checkout_from_tag(self, version):
         package = self.name
@@ -93,15 +93,15 @@ class Hg(BaseVersionControl):
         """
         # The --quiet option ignores untracked (unknown and ignored)
         # files, which seems reasonable.
-        if execute_command('hg status --quiet'):
+        if execute_command(['hg', 'status', '--quiet']):
             # Local changes.
             return False
         return True
 
     def push_commands(self):
         """Return commands to push changes to the server."""
-        return ['hg push']
+        return [['hg', 'push']]
 
     def list_files(self):
         """List files in version control."""
-        return execute_command('hg locate --fullpath').splitlines()
+        return execute_command(['hg', 'locate', '--fullpath']).splitlines()

--- a/zest/releaser/lasttaglog.py
+++ b/zest/releaser/lasttaglog.py
@@ -27,5 +27,5 @@ def main():
     logger.info("Showing log since tag %s and the last commit.",
                 full_tag)
     log_command = vcs.cmd_log_since_tag(found)
-    print(log_command)
+    print(utils.format_command(log_command))
     print(execute_command(log_command))

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -82,7 +82,7 @@ class Releaser(baserelease.Basereleaser):
                  "if there are differences?" % version)
             if utils.ask(q):
                 diff_command = self.vcs.cmd_diff_last_commit_against_tag(tag)
-                print(diff_command)
+                print(utils.format_command(diff_command))
                 print(execute_command(diff_command))
         else:
             self.data['tag_already_exists'] = False
@@ -93,12 +93,13 @@ class Releaser(baserelease.Basereleaser):
         if self.data['tag_already_exists']:
             return
         cmds = self.vcs.cmd_create_tag(tag, self.data['tag-signing'])
-        if not isinstance(cmds, list):
+        assert isinstance(cmds, (list, tuple)) # transitional guard
+        if not isinstance(cmds[0], (list, tuple)):
             cmds = [cmds]
         if len(cmds) == 1:
             print("Tag needed to proceed, you can use the following command:")
         for cmd in cmds:
-            print(cmd)
+            print(utils.format_command(cmd))
             if utils.ask("Run this command"):
                 print(execute_command(cmd))
             else:

--- a/zest/releaser/tests/bzr.txt
+++ b/zest/releaser/tests/bzr.txt
@@ -41,7 +41,7 @@ Make a change:
     ...    _ = f.write('\na = 2\n')
     >>> cmd = checkout.cmd_diff()
     >>> cmd
-    'bzr diff'
+    ['bzr', 'diff']
     >>> print(execute_command(cmd))
     === modified file 'setup.py'
     --- setup.py	...
@@ -57,7 +57,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    'bzr commit -v -m "small tweak"'
+    ['bzr', 'commit', '-v', '-m', 'small tweak']
     >>> print(execute_command(cmd))
     RED Committing to: TESTTEMP/tha.example-bzr/
     RED modified setup.py
@@ -78,7 +78,7 @@ Create a tag and it will show up:
 
     >>> cmd = checkout.cmd_create_tag('0.1')
     >>> cmd
-    'bzr tag 0.1'
+    ['bzr', 'tag', '0.1']
     >>> dont_care = execute_command(cmd)
     >>> checkout.available_tags()
     ['0.1']
@@ -103,7 +103,7 @@ Now we can request the changes since a specific tag:
 
     >>> cmd = checkout.cmd_diff_last_commit_against_tag('0.1')
     >>> cmd
-    'bzr diff -r tag:0.1..-1'
+    ['bzr', 'diff', '-r', 'tag:0.1..-1']
     >>> print(execute_command(cmd))
     === modified file 'setup.py'
     --- setup.py	...

--- a/zest/releaser/tests/fullrelease.txt
+++ b/zest/releaser/tests/fullrelease.txt
@@ -19,7 +19,7 @@ An svn checkout of a project:
     >>> import os
     >>> os.chdir(svnsourcedir)
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("svn info %s" % svnsourcedir))
+    >>> print(execute_command(["svn", "info", svnsourcedir]))
     Path: ...
     URL: file://TESTREPO/tha.example/trunk
     ...

--- a/zest/releaser/tests/functional-bzr.txt
+++ b/zest/releaser/tests/functional-bzr.txt
@@ -17,7 +17,7 @@ A Bazaar directory (repository and checkout in one):
 There are no tags yet:
 
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("bzr tags"))
+    >>> print(execute_command(["bzr", "tags"]))
 
 The changelog is unreleased:
 
@@ -109,7 +109,7 @@ The release script tags the release and uploads it:
 
 There is now a tag:
 
-    >>> print(execute_command("bzr tags"))
+    >>> print(execute_command(["bzr", "tags"]))
     0.1                  2
 
 And the postrelease script ups the version:

--- a/zest/releaser/tests/functional-git.txt
+++ b/zest/releaser/tests/functional-git.txt
@@ -17,7 +17,7 @@ A git directory (repository and checkout in one):
 There are no tags yet:
 
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("git tag"))
+    >>> print(execute_command(["git", "tag"]))
     <BLANKLINE>
 
 The changelog is unreleased:
@@ -83,7 +83,7 @@ known on PyPI:
     >>> release.main()
     Checking data dict
     Tag needed to proceed, you can use the following command:
-    git tag 0.1 -m "Tagging 0.1"
+    git tag 0.1 -m 'Tagging 0.1'
     Question: Run this command (Y/n)?
     Our reply: y
     <BLANKLINE>
@@ -115,7 +115,7 @@ known on PyPI:
 
 There is now a tag:
 
-    >>> print(execute_command("git tag"))
+    >>> print(execute_command(["git", "tag"]))
     0.1
 
 And the postrelease script ups the version:
@@ -159,6 +159,6 @@ The changelog and setup.py are at 0.2 and indicate dev mode:
 
 And there are no uncommitted changes:
 
-    >>> print(execute_command("git status"))
+    >>> print(execute_command(["git", "status"]))
     On branch master
     nothing to commit, working directory clean

--- a/zest/releaser/tests/functional-mercurial.txt
+++ b/zest/releaser/tests/functional-mercurial.txt
@@ -17,7 +17,7 @@ A mercurial directory (repository and checkout in one):
 There are no tags yet:
 
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("hg tags"))
+    >>> print(execute_command(["hg", "tags"]))
     tip 1:234567890abc
 
 The changelog is unreleased:
@@ -80,7 +80,7 @@ The release script tags the release and uploads it:
     >>> release.main()
     Checking data dict
     Tag needed to proceed, you can use the following command:
-    hg tag -m "Tagging 0.1" 0.1
+    hg tag -m 'Tagging 0.1' 0.1
     Question: Run this command (Y/n)?
     Our reply: y
     <BLANKLINE>
@@ -109,7 +109,7 @@ The release script tags the release and uploads it:
 
 There is now a tag:
 
-    >>> print(execute_command("hg tags"))
+    >>> print(execute_command(["hg", "tags"]))
     tip  1:234567890abc
     0.1  1:234567890abc
 

--- a/zest/releaser/tests/functional-svn.txt
+++ b/zest/releaser/tests/functional-svn.txt
@@ -19,14 +19,14 @@ An svn checkout of a project:
     >>> import os
     >>> os.chdir(svnsourcedir)
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("svn info %s" % svnsourcedir))
+    >>> print(execute_command(["svn", "info", svnsourcedir]))
     Path: ...tha.example-svn...
     file://TESTREPO/tha.example/trunk
     ...
 
 There are no tags yet:
 
-    >>> print(execute_command("svn list %s/tha.example/tags" % repo_url))
+    >>> print(execute_command(["svn", "list", "%s/tha.example/tags" % repo_url]))
 
 The changelog is unreleased:
 
@@ -88,7 +88,7 @@ The release script tags the release and uploads it:
     >>> release.main()
     Checking data dict
     Tag needed to proceed, you can use the following command:
-    svn cp --non-interactive file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m "Tagging 0.1"
+    svn cp --non-interactive file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m 'Tagging 0.1'
     Question: Run this command (Y/n)?
     Our reply: y
     <BLANKLINE>
@@ -126,7 +126,7 @@ that we upload to alternative pypis as well.
 
 There is now a tag:
 
-    >>> print(execute_command("svn list %s/tha.example/tags" % repo_url))
+    >>> print(execute_command(["svn", "list", "%s/tha.example/tags" % repo_url]))
     0.1/
 
 And the postrelease script ups the version:

--- a/zest/releaser/tests/functional-with-hooks.txt
+++ b/zest/releaser/tests/functional-with-hooks.txt
@@ -79,7 +79,7 @@ The release script tags the release and uploads it:
     releaser_middle
     Checking data dict
     Tag needed to proceed, you can use the following command:
-    git tag 0.1 -m "Tagging 0.1"
+    git tag 0.1 -m 'Tagging 0.1'
     Question: Run this command (Y/n)?
     Our reply: y
     <BLANKLINE>

--- a/zest/releaser/tests/functional.py
+++ b/zest/releaser/tests/functional.py
@@ -73,60 +73,63 @@ def setup(test):
     # "Expected FS format between '1' and '4'; found format '6'"
     # But on svn 1.6, this option is not available so it crashes.  So we try.
     result = execute_command(
-        'svnadmin create --compatible-version=1.6 %s' % repodir)
+        ['svnadmin', 'create', '--compatible-version=1.6', repodir])
     if Fore.RED in result:
-        execute_command('svnadmin create %s' % repodir)
+        execute_command(['svnadmin', 'create', repodir])
 
     repo_url = 'file://' + repodir  # TODO: urllib or so for windows
     # Import example project
-    execute_command('svn mkdir %s/tha.example -m "mkdir"' % repo_url)
-    execute_command('svn mkdir %s/tha.example/tags -m "mkdir"' % repo_url)
     execute_command(
-        'svn import %s %s/tha.example/trunk -m "import"' % (sourcedir,
-                                                            repo_url))
+        ['svn', 'mkdir', '%s/tha.example' % repo_url, '-m', 'mkdir'])
+    execute_command(
+        ['svn', 'mkdir', '%s/tha.example/tags'  % repo_url, '-m', 'mkdir'])
+    execute_command(
+        ['svn', 'import', sourcedir, '%s/tha.example/trunk' % repo_url,
+         '-m', 'import'])
     # Subversion checkout
     svnsourcedir = os.path.join(test.tempdir, 'tha.example-svn')
     execute_command(
-        'svn co %s/tha.example/trunk %s' % (repo_url, svnsourcedir))
+        ['svn', 'co', '%s/tha.example/trunk' % repo_url, svnsourcedir])
     execute_command(
-        'svn propset svn:ignore "tha.example.egg-info *.pyc" %s/src ' %
-        svnsourcedir)
-    execute_command('svn up %s' % svnsourcedir)
-    execute_command('svn commit %s -m "ignoring egginfo"' % svnsourcedir)
+        ['svn', 'propset', 'svn:ignore', 'tha.example.egg-info *.pyc',
+         '%s/src' % svnsourcedir])
+    execute_command(['svn', 'up', svnsourcedir])
+    execute_command(['svn', 'commit', svnsourcedir, '-m', 'ignoring egginfo'])
 
     # Mercurial initialization
     hgsourcedir = os.path.join(test.tempdir, 'tha.example-hg')
     shutil.copytree(sourcedir, hgsourcedir)
-    execute_command("hg init %s" % hgsourcedir)
+    execute_command(['hg', 'init', hgsourcedir])
     with open(os.path.join(hgsourcedir, '.hgignore'), 'wb') as f:
         f.write('tha.example.egg-info\n\\.pyc$\n'.encode('utf-8'))
-    execute_command("hg add %s" % hgsourcedir)
-    execute_command("hg commit -m 'init' %s" % hgsourcedir)
+    execute_command(["hg", "add", hgsourcedir])
+    execute_command(["hg", "commit", "-m", "init", hgsourcedir])
 
     # Bazaar initialization
     bzrsourcedir = os.path.join(test.tempdir, 'tha.example-bzr')
     shutil.copytree(sourcedir, bzrsourcedir)
-    execute_command("bzr init %s" % bzrsourcedir)
+    execute_command(["bzr", "init", bzrsourcedir])
     with open(os.path.join(bzrsourcedir, '.bzrignore'), 'w') as f:
         f.write('tha.example.egg-info\n*.pyc\n')
-    execute_command("bzr add %s" % bzrsourcedir)
-    execute_command("bzr commit -m 'init' %s" % bzrsourcedir)
+    execute_command(["bzr", "add", bzrsourcedir])
+    execute_command(["bzr", "commit", "-m", "init", bzrsourcedir])
 
     # Git initialization
     gitsourcedir = os.path.join(test.tempdir, 'tha.example-git')
     shutil.copytree(sourcedir, gitsourcedir)
     os.chdir(gitsourcedir)
-    execute_command("git init")
+    execute_command(["git", "init"])
     with open(os.path.join(gitsourcedir, '.gitignore'), 'w') as f:
         f.write('tha.example.egg-info\n*.pyc\n')
-    execute_command("git add .")
-    execute_command("git commit -a -m 'init'")
+    execute_command(["git", "add", "."])
+    execute_command(["git", "commit", "-a", "-m", "init"])
     os.chdir(test.orig_dir)
 
     # Git svn initialization
     gitsvnsourcedir = os.path.join(test.tempdir, 'tha.example-gitsvn')
     execute_command(
-        'git svn clone -s %s/tha.example %s' % (repo_url, gitsvnsourcedir))
+        ["git", "svn", "clone", "-s", "%s/tha.example" % repo_url,
+         gitsvnsourcedir])
     os.chdir(test.orig_dir)
 
     def svnhead(*filename_parts):

--- a/zest/releaser/tests/git.txt
+++ b/zest/releaser/tests/git.txt
@@ -8,7 +8,7 @@ Detailed tests of git.py
 Some initial imports:
 
     >>> from zest.releaser import git
-    >>> from zest.releaser.utils import execute_command
+    >>> from zest.releaser.utils import execute_command, execute_commands
     >>> import os
 
 Project name
@@ -41,7 +41,7 @@ Make a change:
     ...    _ = f.write('\na = 2\n')
     >>> cmd = checkout.cmd_diff()
     >>> cmd
-    'git diff'
+    ['git', 'diff']
     >>> print(execute_command(cmd))
     diff --git a/setup.py b/setup.py
     index 9c14143..54fa3b9 100644
@@ -58,7 +58,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    'git commit -a -m "small tweak"'
+    ['git', 'commit', '-a', '-m', 'small tweak']
 
 In some cases we get this output:
 ``[master ...] small tweak``
@@ -82,7 +82,7 @@ Create a tag and it will show up:
 
     >>> cmd = checkout.cmd_create_tag('0.1')
     >>> cmd
-    'git tag 0.1 -m "Tagging 0.1"'
+    ['git', 'tag', '0.1', '-m', 'Tagging 0.1']
     >>> dont_care = execute_command(cmd)
     >>> checkout.available_tags()
     ['0.1']
@@ -106,7 +106,7 @@ Now we can request the changes since a specific tag:
 
     >>> cmd = checkout.cmd_diff_last_commit_against_tag('0.1')
     >>> cmd
-    'git diff 0.1'
+    ['git', 'diff', '0.1']
     >>> print(execute_command(cmd))
     diff --git a/setup.py b/setup.py
     index 9c14143..54fa3b9 100644
@@ -138,7 +138,7 @@ other version control systems too.
 So we first switch back to the tag.
 
     >>> cmd = checkout.cmd_checkout_from_tag('0.1', gitsourcedir)
-    >>> print(execute_command(cmd))
+    >>> print(execute_commands(cmd))
     RED Note: ...0.1...
     RED HEAD is now at ... small tweak
 
@@ -172,8 +172,9 @@ though we are already at the correct tag.
     >>> os.chdir(temp)
     >>> cmd = checkout.cmd_checkout_from_tag('0.1', temp)
     >>> cmd
-    'git checkout 0.1 && git submodule update --init --recursive'
-    >>> print(execute_command(cmd))
+    [['git', 'checkout', '0.1'],
+     ['git', 'submodule', 'update', '--init', '--recursive']]
+    >>> print(execute_commands(cmd))
     RED HEAD is now at ... small tweak
 
 The tempdir should be at tag 0.1.  The last line ought to be "a = 2"
@@ -186,8 +187,9 @@ The tempdir should be at tag 0.1.  The last line ought to be "a = 2"
 Change back to the source directory and return to the master branch.
 
     >>> os.chdir(gitsourcedir)
-    >>> cmd = 'git checkout master && git submodule update --init --recursive'
-    >>> print(execute_command(cmd))
+    >>> cmd = [['git', 'checkout', 'master'],
+    ... ['git', 'submodule', 'update', '--init', '--recursive']]
+    >>> print(execute_commands(cmd))
     RED Previous HEAD position was ... small tweak
     RED Switched to branch 'master'
 
@@ -197,4 +199,4 @@ Pushing changes
 For git, committing isn't enough. We need to push changes to the server:
 
     >>> checkout.push_commands()
-    ['git push', 'git push --tags']
+    [['git', 'push'], ['git', 'push', '--tags']]

--- a/zest/releaser/tests/gitsvn.txt
+++ b/zest/releaser/tests/gitsvn.txt
@@ -41,7 +41,7 @@ Make a change:
     ...     _ = f.write('\na = 2\n')
     >>> cmd = checkout.cmd_diff()
     >>> cmd
-    'git diff'
+    ['git', 'diff']
     >>> print(execute_command(cmd))
     diff --git a/setup.py b/setup.py
     index 9c14143..54fa3b9 100644
@@ -58,7 +58,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    'git commit -a -m "small tweak"'
+    ['git', 'commit', '-a', '-m', 'small tweak']
 
 In some cases we get this output:
 ``[master ...] small tweak``
@@ -88,9 +88,9 @@ Create a tag and it will show up (master diverges from trunk):
     Your local master diverges from trunk.
     <BLANKLINE>
     >>> cmds
-    ['git svn dcommit',
-     'git tag 0.1 -m "Tagging 0.1"',
-     'git svn tag -m "Tagging 0.1" 0.1']
+    [['git', 'svn', 'dcommit'],
+     ['git', 'tag', '0.1', '-m', 'Tagging 0.1'],
+     ['git', 'svn', 'tag', '-m', 'Tagging 0.1', '0.1']]
     >>> for cmd in cmds:
     ...     dont_care = execute_command(cmd)
     >>> checkout.available_tags()
@@ -104,8 +104,8 @@ Create a tag and it will show up (master == trunk):
     <BLANKLINE>
     You are on branch master.
     >>> cmds
-    ['git tag 0.2 -m "Tagging 0.2"',
-     'git svn tag -m "Tagging 0.2" 0.2']
+    [['git', 'tag', '0.2', '-m', 'Tagging 0.2'],
+     ['git', 'svn', 'tag', '-m', 'Tagging 0.2', '0.2']]
     >>> for cmd in cmds:
     ...     dont_care = execute_command(cmd)
     >>> checkout.available_tags()
@@ -113,7 +113,7 @@ Create a tag and it will show up (master == trunk):
 
 Work on a branch different from master (unsupported):
 
-    >>> dontcare = execute_command('git checkout -b foo')
+    >>> dontcare = execute_command(['git', 'checkout', '-b', 'foo'])
     >>> cmds = checkout.cmd_create_tag('0.3')
     Traceback (most recent call last):
     ...

--- a/zest/releaser/tests/hg.txt
+++ b/zest/releaser/tests/hg.txt
@@ -41,7 +41,7 @@ Make a change:
     ...    _ = f.write('\na = 2\n')
     >>> cmd = checkout.cmd_diff()
     >>> cmd
-    'hg diff'
+    ['hg', 'diff']
     >>> print(execute_command(cmd))
     diff -r 234567890abc setup.py
     --- a/setup.py    ...
@@ -57,7 +57,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    'hg commit -v -m "small tweak"'
+    ['hg', 'commit', '-v', '-m', 'small tweak']
     >>> print(execute_command(cmd))
     setup.py...
     committed changeset 1:234567890abc
@@ -75,7 +75,7 @@ Create a tag and it will show up:
 
     >>> cmd = checkout.cmd_create_tag('0.1')
     >>> cmd
-    'hg tag -m "Tagging 0.1" 0.1'
+    ['hg', 'tag', '-m', 'Tagging 0.1', '0.1']
     >>> dont_care = execute_command(cmd)
     >>> checkout.available_tags()
     ['0.1']
@@ -99,7 +99,7 @@ Now we can request the changes since a specific tag:
 
     >>> cmd = checkout.cmd_diff_last_commit_against_tag('0.1')
     >>> cmd
-    'hg diff -r 0.1 -r 234567890abc'
+    ['hg', 'diff', '-r', '0.1', '-r', '234567890abc']
     >>> print(execute_command(cmd))
     diff -r 234567890abc -r 234567890abc .hgtags
     --- /dev/null     ...
@@ -149,4 +149,4 @@ Pushing changes
 For hg, committing isn't enough. We need to push changes to the server:
 
     >>> checkout.push_commands()
-    ['hg push']
+    [['hg', 'push']]

--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -19,7 +19,7 @@ An svn checkout of a project:
     >>> import os
     >>> os.chdir(svnsourcedir)
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("svn info %s" % svnsourcedir))
+    >>> print(execute_command(["svn", "info", svnsourcedir]))
     Path: ...
     URL: file://TESTREPO/tha.example/trunk
     ...

--- a/zest/releaser/tests/prerelease.txt
+++ b/zest/releaser/tests/prerelease.txt
@@ -19,7 +19,7 @@ An svn checkout of a project:
     >>> import os
     >>> os.chdir(svnsourcedir)
     >>> from zest.releaser.utils import execute_command
-    >>> print(execute_command("svn info %s" % svnsourcedir))
+    >>> print(execute_command(["svn", "info", svnsourcedir]))
     Path: ...
     URL: file://TESTREPO/tha.example/trunk
     ...

--- a/zest/releaser/tests/svn.txt
+++ b/zest/releaser/tests/svn.txt
@@ -41,7 +41,7 @@ Make a change:
     ...     _ = f.write('\na = 2\n')
     >>> cmd = checkout.cmd_diff()
     >>> cmd
-    'svn diff --non-interactive'
+    ['svn', 'diff', '--non-interactive']
     >>> print(execute_command(cmd))
     Index: ...
     --- setup.py      (revision 3)
@@ -57,7 +57,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    'svn commit --non-interactive -m "small tweak"'
+    ['svn', 'commit', '--non-interactive', '-m', 'small tweak']
     >>> print(execute_command(cmd))
     Sending        setup.py
     Transmitting file data...
@@ -80,7 +80,9 @@ Create a tag and it will show up:
 
     >>> cmd = checkout.cmd_create_tag('0.1')
     >>> cmd
-    'svn cp --non-interactive file://TESTREPO/tha.example/trunk file://TESTREPO/tha.example/tags/0.1 -m "Tagging 0.1"'
+    ['svn', 'cp', '--non-interactive',
+     'file://TESTREPO/tha.example/trunk',
+     'file://TESTREPO/tha.example/tags/0.1', '-m', 'Tagging 0.1']
     >>> dont_care = execute_command(cmd)
     >>> checkout.available_tags()
     ['0.1']
@@ -106,7 +108,9 @@ post-commit hooks:
 
     >>> cmd = checkout.cmd_diff_last_commit_against_tag('0.1')
     >>> cmd
-    'svn --non-interactive diff file://TESTREPO/tha.example/tags/0.1 file://TESTREPO/tha.example/trunk'
+    ['svn', '--non-interactive', 'diff',
+     'file://TESTREPO/tha.example/tags/0.1',
+     'file://TESTREPO/tha.example/trunk']
     >>> print(execute_command(cmd))
     Index: setup.py
     ===================================================================
@@ -135,7 +139,9 @@ The tag checkout command makes a checkout in that tempdir:
 
     >>> cmd = checkout.cmd_checkout_from_tag('0.1', temp)
     >>> cmd
-    'svn co --non-interactive file://TESTREPO/tha.example/tags/0.1 TMPDIR/somename...'
+    ['svn', 'co', '--non-interactive',
+     'file://TESTREPO/tha.example/tags/0.1',
+      'TMPDIR/somename...']
     >>> print('\n'.join(sorted(execute_command(cmd).splitlines())))
     A    TMPDIR/somename.../CHANGES.txt
     A    TMPDIR/somename.../README.txt
@@ -196,15 +202,15 @@ Set up a new sample project in the repository:
 
     >>> repo_url
     'file://TESTREPO'
-    >>> cmd = 'svn mkdir %s/sample -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/sample' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
-    >>> cmd = 'svn mkdir %s/sample/trunk -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/sample/trunk' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
 
 Make a checkout:
 
     >>> os.chdir(tempdir)
-    >>> cmd = 'svn co %s/sample/trunk sample' % repo_url
+    >>> cmd = ['svn', 'co', '%s/sample/trunk' % repo_url, 'sample']
     >>> dont_care = execute_command(cmd)
     >>> os.chdir('sample')
 
@@ -247,7 +253,7 @@ obviously an empty list:
     []
     >>> print(sample_checkout._tags_name)
     tags
-    >>> cmd = 'svn list %s/sample' % repo_url
+    >>> cmd = ['svn', 'list', '%s/sample' % repo_url]
     >>> print(execute_command(cmd))
     tags/
     trunk/
@@ -264,22 +270,22 @@ Set up a new sample project in the repository:
 
     >>> repo_url
     'file://TESTREPO'
-    >>> cmd = 'svn mkdir %s/singular -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/singular' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
-    >>> cmd = 'svn mkdir %s/singular/trunk -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/singular/trunk' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
 
 And make a /tag directory.  We don't support adding one ourselves (we always
 suggest /tags, make a /tag dir yourself if you really really need it), but we
 *do* detect and use one:
 
-    >>> cmd = 'svn mkdir %s/singular/tag -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/singular/tag' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
 
 Make a checkout:
 
     >>> os.chdir(tempdir)
-    >>> cmd = 'svn co %s/singular/trunk singular' % repo_url
+    >>> cmd = ['svn', 'co', '%s/singular/trunk' % repo_url, 'singular']
     >>> dont_care = execute_command(cmd)
     >>> os.chdir('singular')
 
@@ -310,25 +316,29 @@ Tag and checkout commands also use the singular:
 
     >>> cmd = singular_checkout.cmd_checkout_from_tag('0.1', temp)
     >>> cmd
-    'svn co --non-interactive file://TESTREPO/singular/tag/0.1 TMPDIR/somename...'
+    ['svn', 'co', '--non-interactive',
+     'file://TESTREPO/singular/tag/0.1',
+     'TMPDIR/somename...']
     >>> cmd = singular_checkout.cmd_create_tag('0.1')
     >>> cmd
-    'svn cp --non-interactive file://TESTREPO/singular/trunk file://TESTREPO/singular/tag/0.1 -m "Tagging 0.1"'
+    ['svn', 'cp', '--non-interactive',
+     'file://TESTREPO/singular/trunk',
+     'file://TESTREPO/singular/tag/0.1', '-m', 'Tagging 0.1']
 
 If we have branch checkout, the base url is still extracted correctly, even if
 the singular /tag and /branch is used:
 
-    >>> cmd = 'svn mkdir %s/singular/branch -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/singular/branch' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
-    >>> cmd = 'svn mkdir %s/singular/branch/mybranch -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/singular/branch/mybranch' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
-    >>> cmd = 'svn mkdir %s/singular/tag/mytag -m "mkdir"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/singular/tag/mytag' % repo_url, '-m', 'mkdir']
     >>> dont_care = execute_command(cmd)
 
     >>> os.chdir(tempdir)
-    >>> cmd = 'svn co %s/singular/branch/mybranch mysingularbranch' % repo_url
+    >>> cmd = ['svn', 'co', '%s/singular/branch/mybranch' % repo_url, 'mysingularbranch']
     >>> dont_care = execute_command(cmd)
-    >>> cmd = 'svn co %s/singular/tag/mytag mysingulartag' % repo_url
+    >>> cmd = ['svn', 'co', '%s/singular/tag/mytag' % repo_url, 'mysingulartag']
     >>> dont_care = execute_command(cmd)
 
     >>> os.chdir(tempdir)
@@ -376,15 +386,15 @@ Create trunk/ for both projects:
 
     >>> repo_url
     'file://TESTREPO'
-    >>> cmd = 'svn mkdir --parents %s/trunk/projectA/trunk -m"mk projectA"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '--parents', '%s/trunk/projectA/trunk' % repo_url, '-m', 'mk projectA']
     >>> dont_care = execute_command(cmd)
-    >>> cmd = 'svn mkdir %s/trunk/projectB/trunk -m "mkdir projectB"' % repo_url
+    >>> cmd = ['svn', 'mkdir', '%s/trunk/projectB/trunk' % repo_url, '-m', 'mkdir projectB']
     >>> dont_care = execute_command(cmd)
 
 Make a checkout:
 
     >>> os.chdir(tempdir)
-    >>> cmd = 'svn co %s/trunk' % repo_url
+    >>> cmd = ['svn', 'co', '%s/trunk' % repo_url]
     >>> dont_care = execute_command(cmd)
 
 Now check that we try to create the proper trunk/projectA/tags directory
@@ -401,7 +411,7 @@ Now check that we try to create the proper trunk/projectA/tags directory
     <BLANKLINE>
     Committed revision 18.
     []
-    >>> cmd = 'svn list -R %s/trunk' % repo_url
+    >>> cmd = ['svn', 'list', '-R', '%s/trunk' % repo_url]
     >>> print(execute_command(cmd))
     projectA/
     projectA/tags/

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -449,7 +449,7 @@ Running commands
 
 We can run commands.
 
-    >>> print(utils.execute_command('echo "E.T. phone home."'))
+    >>> print(utils.execute_command(['echo', "E.T. phone home."]))
     E.T. phone home.
 
 We want to discover errors and show them in red.
@@ -458,13 +458,18 @@ We want to discover errors and show them in red.
     '\x1b[31m'
     >>> Fore.MAGENTA
     '\x1b[35m'
-    >>> utils.execute_command('ls some-non-existing-file')
+    >>> utils.execute_command(['ls', 'some-non-existing-file'])
     '\x1b[31mls...'
 
 Warnings may also end up in the error output.  That may be unwanted.
+Note: Setting ``__command_is_string__`` is a special hack implemented
+only for this test-case.  It makes ``utils._execute_command()`` to
+accept a command-string and execute it via a shell.
 
     >>> warning = "warning: no previously-included files matching '*.pyc' found anywhere in distribution."
+    >>> utils.__command_is_string__ = True
     >>> result = utils.execute_command('echo %s > /dev/stderr' % warning)
+    >>> utils.__command_is_string__ = False
     >>> result.startswith(Fore.RED)
     False
     >>> result.startswith(Fore.MAGENTA)
@@ -476,7 +481,9 @@ One similar harmless warning by distutils does not get the 'warning:'
 prefixed, so we handle it explicitly:
 
     >>> warning = "no previously-included directories found matching devsrc"
+    >>> utils.__command_is_string__ = True
     >>> result = utils.execute_command('echo %s > /dev/stderr' % warning)
+    >>> utils.__command_is_string__ = False
     >>> result.startswith(Fore.RED)
     False
     >>> result.startswith(Fore.MAGENTA)
@@ -490,7 +497,9 @@ Let's do a combination:
     ... Warn: What is the answer to life, the universe and everything?
     ...
     ... 41"""
+    >>> utils.__command_is_string__ = True
     >>> result = utils.execute_command('echo "%s" > /dev/stderr' % message)
+    >>> utils.__command_is_string__ = False
     >>> result
     '\x1b[35mWarn: What is the answer to life, the universe and everything?\n\n\x1b[31m41'
     >>> print(result)
@@ -517,7 +526,7 @@ significantly on different systems, so we do not check the exact line.
 The user can choose to quit:
 
     >>> utils.test_answer_book.set_answers(['q'])
-    >>> utils.execute_command('ls some-non-existing-file', allow_retry=True)
+    >>> utils.execute_command(['ls', 'some-non-existing-file'], allow_retry=True)
     Traceback (most recent call last):
     ...
     zest.releaser.utils.CommandException: Command failed: 'ls some-non-existing-file'
@@ -525,7 +534,7 @@ The user can choose to quit:
 The user can choose to not retry and just continue:
 
     >>> utils.test_answer_book.set_answers(['n'])
-    >>> result = utils.execute_command('ls some-non-existing-file', allow_retry=True)
+    >>> result = utils.execute_command(['ls', 'some-non-existing-file'], allow_retry=True)
     RED ls...
     RED There were errors or warnings.
     Question: Retry this command? [Yes/no/quit/?]
@@ -536,7 +545,7 @@ The user can choose to not retry and just continue:
 And there is the retry.  In the end you do have to choose something:
 
     >>> utils.test_answer_book.set_answers(['y', 'y', 'n'])
-    >>> result = utils.execute_command('ls some-non-existing-file', allow_retry=True)
+    >>> result = utils.execute_command(['ls', 'some-non-existing-file'], allow_retry=True)
     RED ls...
     RED There were errors or warnings.
     Question: Retry this command? [Yes/no/quit/?]
@@ -552,7 +561,7 @@ And there is the retry.  In the end you do have to choose something:
     >>> print(result)
     RED ls...
     >>> utils.test_answer_book.set_answers(['y', 'y', 'q'])
-    >>> utils.execute_command('ls some-non-existing-file', allow_retry=True)
+    >>> utils.execute_command(['ls', 'some-non-existing-file'], allow_retry=True)
     Traceback (most recent call last):
     ...
     zest.releaser.utils.CommandException: Command failed: 'ls some-non-existing-file'
@@ -672,9 +681,10 @@ Safe setup.py running
 ``setup_py()`` returns the ``python setup.py xyz`` command line by using
 sys.executable.
 
-    >>> cmd = utils.setup_py('cook a cow')
-    >>> print(cmd.replace(sys.executable, 'python'))  # test normalization
-    python setup.py cook a cow
+    >>> cmd = utils.setup_py('cook', 'a', 'cow')
+    >>> cmd[0] = cmd[0].replace(sys.executable, 'python')  # test normalization
+    >>> print(repr(cmd))
+    ['python', 'setup.py', 'cook', 'a', 'cow']
 
 When the setup.py arguments include arguments that indicate pypi interaction,
 we refuse to work, because this should be done with twine now:

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -348,7 +348,7 @@ class BaseVersionControl(object):
         tagdir = self.prepare_checkout_dir(prefix)
         os.chdir(tagdir)
         cmd = self.cmd_checkout_from_tag(version, tagdir)
-        print(utils.execute_command(cmd))
+        print(utils.execute_commands(cmd))
 
     def is_clean_checkout(self):
         "Is this a clean checkout?"


### PR DESCRIPTION
This avoids wrong quoting in arguments if one e.g. passes a
double-quote in a message.

- Convert all command-strings into lists.
- New function ``utils.excute_commands()`` (plural).
- New function ``utils.format_commands()``.
- Incompatible: ``git.cmd_checkout_from_tag()`` now returns a list
  of commands, not a single one.
- Adjusted tests.

Closes #233.