### PR TITLE
Doc updates: Reorder sections and shorten titles

### DIFF
--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -1,0 +1,2 @@
+
+.. include:: ../../CREDITS.rst

--- a/doc/source/developing.rst
+++ b/doc/source/developing.rst
@@ -1,5 +1,5 @@
-Information for developers of zest.releaser
-===========================================
+Information for developers
+==========================
 
 Running tests
 -------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -26,7 +26,7 @@ bugs and fixing the code:
 .. toctree::
    :maxdepth: 1
 
-   project
+   Improving zest.releaser <project>
    developing
    changelog
    credits

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,6 +17,7 @@ documentation on *using* zest.releaser:
    versions
    uploading
    assumptions
+   entrypoints
    further_reading
 
 And documentation on zest.releaser as a project; for instance for reporting
@@ -27,5 +28,5 @@ bugs and fixing the code:
 
    project
    developing
-   entrypoints
    changelog
+   credits

--- a/doc/source/project.rst
+++ b/doc/source/project.rst
@@ -23,5 +23,3 @@ options:
   <mailto:reinout@vanrees.org>`_ and `maurits@vanrees.org
   <mailto:maurits@vanrees.org>`_. Please email us both at the same time, this
   way at least one of us can give you a quick reply.
-
-.. include:: ../../CREDITS.rst


### PR DESCRIPTION
- Reorder documentation sections.
- Shorten "Developer" section title.
- Shorten "Project" title in the contents side-bar.

I've put thse into a pull-request of it's own since they might be a bit controversy.