### PR TITLE
Bugfix for "git --sign" typo

### DIFF
--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -81,7 +81,7 @@ class Git(BaseVersionControl):
     def cmd_create_tag(self, version, message, sign=False):
         cmd = ['git', 'tag', version, '-m', message]
         if sign:
-            cmd.append["--sign"]
+            cmd.append("--sign")
         if os.path.isdir('.git/svn'):
             print("\nEXPERIMENTAL support for git-svn tagging!\n")
             with open('.git/HEAD') as f:

--- a/zest/releaser/tests/git.txt
+++ b/zest/releaser/tests/git.txt
@@ -87,6 +87,14 @@ Create a tag and it will show up:
     >>> checkout.available_tags()
     ['0.1']
 
+We could have signed the tag, too (though we won't execute the actual command
+as it would need gpg setup on the test machine):
+
+    >>> cmd = checkout.cmd_create_tag('0.1', 'Creating tag 0.1', sign=True)
+    >>> cmd
+    ['git', 'tag', '0.1', '-m', 'Creating tag 0.1', '--sign']
+
+
 A specific tag url is important for subversion, but nonsensical for
 git.  We just return the version as-is:
 


### PR DESCRIPTION
You can never have enough tests :-)