### PR TITLE
Fixed tests with mercurial 4.4+.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for zest.releaser
 6.13.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed tests with mercurial 4.4+.  [maurits]
 
 
 6.13.1 (2017-11-13)

--- a/zest/releaser/tests/test_setup.py
+++ b/zest/releaser/tests/test_setup.py
@@ -101,6 +101,9 @@ checker = renormalizing.RENormalizing([
     # svn 1.9 prints 'Committing transaction...'
     (re.compile('Committing transaction...'), ''),
     (re.compile('FileNotFoundError'), 'IOError'),
+    # mercurial 4.4.1 includes an extra line in checkout_from_tag, e.g.:
+    # new changesets 234567890abc:234567890abc
+    (re.compile('new changesets [0-9a-f]{12}:[0-9a-f]{12}'), ''),
 ] + ([
 
 ] if six.PY3 else [


### PR DESCRIPTION
I updated with mac homebrew to mercurial 4.4.1 today (I don't know what the previous version exactly was).
This gave a test error because it prints an extra line.

```
File "/Users/maurits/tools/src/zest.releaser/zest/releaser/tests/hg.txt", line 127, in hg.txt
Failed example:
    checkout.checkout_from_tag('0.1')
Differences (ndiff with -expected +actual):
    -
      adding changesets
      adding manifests
      adding file changes
    - added 2 changesets with ... changes to 17 files
    ?                         ^^^
    + added 2 changesets with 18 changes to 17 files
    ?                         ^^
    + new changesets 234567890abc:234567890abc
      updating to branch default
      17 files updated, 0 files merged, 0 files removed, 0 files unresolved
    + <BLANKLINE>
```

I fixed it by removing this line in our test output normalizer.