### PR TITLE
Try output encodings in the right order please

### DIFF
--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -71,7 +71,7 @@ def write_text_file(filename, contents, encoding=None):
         # We might have added something to the contents (a changelog entry)
         # that does not fit the detected encoding.  So we try a few encodings.
         orig_encoding = encoding
-        encodings = set([orig_encoding, OUTPUT_ENCODING, 'utf-8'])
+        encodings = [orig_encoding, OUTPUT_ENCODING, 'utf-8']
         for encoding in encodings:
             try:
                 contents = contents.encode(encoding)


### PR DESCRIPTION
Set iteration order is not defined in Python.  This loop is one where the order *matters*, otherwise we could be "upgrading" to UTF-8 without any reason, leading to bugs like #254.

I have not tested that this fix works.

I don't currently have the time to write a unit test that would expose the bug.