### PR TITLE
Write text files with correct encoding on Python3

### DIFF
--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -59,31 +59,35 @@ def loglevel():
 
 
 def write_text_file(filename, contents, encoding=None):
-    if six.PY2 and isinstance(contents, six.text_type):
-        # Python 2 unicode needs to be encoded.
-        if encoding is None:
-            encoding = OUTPUT_ENCODING
-            logger.debug("Writing to %s with the default output encoding %s",
-                         filename, encoding)
-        else:
-            logger.debug("Writing to %s with its original encoding %s",
-                         filename, encoding)
-        # We might have added something to the contents (a changelog entry)
-        # that does not fit the detected encoding.  So we try a few encodings.
-        orig_encoding = encoding
-        encodings = [orig_encoding, OUTPUT_ENCODING, 'utf-8']
-        for encoding in encodings:
-            try:
-                contents = contents.encode(encoding)
-                logger.debug("Encoding we actually used: %s", encoding)
-                break
-            except UnicodeEncodeError:
-                pass
-        else:
-            logger.error("Could not write to file %s with any of these "
-                         "encodings: %s", filename, encodings)
-    with open(filename, 'w') as f:
-        f.write(contents)
+    if six.PY2:
+        if isinstance(contents, six.text_type):
+            # Python 2 unicode needs to be encoded.
+            if encoding is None:
+                encoding = OUTPUT_ENCODING
+                logger.debug("Writing to %s with the default output encoding %s",
+                             filename, encoding)
+            else:
+                logger.debug("Writing to %s with its original encoding %s",
+                             filename, encoding)
+            # We might have added something to the contents (a changelog entry)
+            # that does not fit the detected encoding.  So we try a few encodings.
+            orig_encoding = encoding
+            encodings = [orig_encoding, OUTPUT_ENCODING, 'utf-8']
+            for encoding in encodings:
+                try:
+                    contents = contents.encode(encoding)
+                    logger.debug("Encoding we actually used: %s", encoding)
+                    break
+                except UnicodeEncodeError:
+                    pass
+            else:
+                logger.error("Could not write to file %s with any of these "
+                             "encodings: %s", filename, encodings)
+        with open(filename, 'w') as f:
+            f.write(contents)
+    else:
+        with open(filename, 'w', encoding=encoding) as f:
+            f.write(contents)
 
 
 def read_text_file(filename, encoding=None):


### PR DESCRIPTION
This patch seems to fix #256, but I've only tested on my Windows machine.