### PR TITLE
Fixed IOError when ``setup.cfg`` is missing and no version is found.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog for zest.releaser
 6.13.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed IOError when ``setup.cfg`` is missing and no version is found.
+  [maurits]
 
 
 6.13.3 (2017-12-19)

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -272,20 +272,21 @@ class BaseVersionControl(object):
                 return
 
         good_version = "version = %s" % version
-        setup_cfg_lines, encoding = utils.read_text_file('setup.cfg')
-        setup_cfg_lines = setup_cfg_lines.split('\n')
-        for line_number, line in enumerate(setup_cfg_lines):
-            if VERSION_PATTERN.search(line):
-                logger.debug("Matching version line found: %r", line)
-                if line.startswith(' '):
-                    indentation = line.split('version')[0]
+        if os.path.exists('setup.cfg'):
+            setup_cfg_lines, encoding = utils.read_text_file('setup.cfg')
+            setup_cfg_lines = setup_cfg_lines.split('\n')
+            for line_number, line in enumerate(setup_cfg_lines):
+                if VERSION_PATTERN.search(line):
+                    logger.debug("Matching version line found: %r", line)
+                    if line.startswith(' '):
+                        indentation = line.split('version')[0]
 
-                    good_version = indentation + good_version
-                setup_cfg_lines[line_number] = good_version
-                utils.write_text_file(
-                    'setup.cfg', '\n'.join(setup_cfg_lines), encoding)
-                logger.info("Set setup.cfg's version to %r", version)
-                return
+                        good_version = indentation + good_version
+                    setup_cfg_lines[line_number] = good_version
+                    utils.write_text_file(
+                        'setup.cfg', '\n'.join(setup_cfg_lines), encoding)
+                    logger.info("Set setup.cfg's version to %r", version)
+                    return
 
         logger.error(
             "We could read a version from setup.py, but could not write it "


### PR DESCRIPTION
I got this in a project where the `setup.py` had the version in `__version__` so it could not be written back. `zest.releaser` then reads `setup.cfg` to see if it has a hint on where to find the version. But when `setup.cfg` is missing, it fails:

```
Traceback (most recent call last):
  File "/Users/maurits/tools/bin/prerelease", line 45, in <module>
    sys.exit(zest.releaser.prerelease.main())
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/prerelease.py", line 104, in main
    prereleaser.run()
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/baserelease.py", line 353, in run
    self.execute()
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/prerelease.py", line 68, in execute
    self._write_version()
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/baserelease.py", line 283, in _write_version
    self.vcs.version = self.data['new_version']
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/vcs.py", line 275, in _update_version
    setup_cfg_lines, encoding = utils.read_text_file('setup.cfg')
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/utils.py", line 117, in read_text_file
    with open(filename, 'rb') as filehandler:
IOError: [Errno 2] No such file or directory: u'setup.cfg'
```

With the fix, you still get an error, but it is the intended one:

```
Enter version [3.0.14]: ERROR: We could read a version from setup.py, but could not write it back. See http://zestreleaser.readthedocs.io/en/latest/versions.html for hints.
Traceback (most recent call last):
  File "/Users/maurits/tools/bin/prerelease", line 45, in <module>
    sys.exit(zest.releaser.prerelease.main())
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/prerelease.py", line 104, in main
    prereleaser.run()
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/baserelease.py", line 353, in run
    self.execute()
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/prerelease.py", line 68, in execute
    self._write_version()
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/baserelease.py", line 283, in _write_version
    self.vcs.version = self.data['new_version']
  File "/Users/maurits/tools/src/zest.releaser/zest/releaser/vcs.py", line 296, in _update_version
    raise RuntimeError("Cannot set version")
RuntimeError: Cannot set version
```

This fix is simply an added condition and indenting the original lines unchanged.