### PR TITLE
Quit in postrelease when we cannot find a version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 6.13.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Quit in ``postrelease`` when we cannot find a version.
+  Fixes `issue #262 <https://github.com/zestsoftware/zest.releaser/issues/262>`.
+  [maurits]
 
 
 6.13.4 (2018-02-05)

--- a/zest/releaser/bumpversion.py
+++ b/zest/releaser/bumpversion.py
@@ -76,7 +76,7 @@ class BumpVersion(baserelease.Basereleaser):
         """
         original_version = self.vcs.version
         logger.debug("Extracted version: %s", original_version)
-        if original_version is None:
+        if not original_version:
             logger.critical('No version found.')
             sys.exit(1)
         suggestion = new_version = self.data.get('new_version')

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -61,6 +61,10 @@ class Postreleaser(baserelease.Basereleaser):
     def _ask_for_new_dev_version(self):
         """Ask for and store a new dev version string."""
         current = self.vcs.version
+        logger.debug("Extracted version: %s", current)
+        if not current:
+            logger.critical('No version found.')
+            sys.exit(1)
         # Clean it up to a non-development version.
         current = utils.cleanup_version(current)
         suggestion = utils.suggest_version(

--- a/zest/releaser/prerelease.py
+++ b/zest/releaser/prerelease.py
@@ -78,7 +78,7 @@ class Prereleaser(baserelease.Basereleaser):
         """
         original_version = self.vcs.version
         logger.debug("Extracted version: %s", original_version)
-        if original_version is None:
+        if not original_version:
             logger.critical('No version found.')
             sys.exit(1)
         suggestion = utils.cleanup_version(original_version)


### PR DESCRIPTION
Fixes issue #262.

There were several checks like this already. I made them the same: do not compare with `None`, but check for a False value. That would catch a found but empty version as well.