### PR TITLE
Print commands in a nicer way.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog for zest.releaser
 6.13.6 (unreleased)
 -------------------
 
+- Print commands in a nicer way.
+  You could get ugly output like this, especially on Python 2.7:
+  ``INFO: The '[u'git', u'diff']':``
+  [maurits]
+
 - Test compatibility with Python 2.7, 3.4, 3.5. 3.6.
   We test PyPy2 as well, but it intermittently fails.  [maurits]
 

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -322,7 +322,8 @@ class Basereleaser(object):
             print(diff)
         else:
             # Common case
-            logger.info("The '%s':\n\n%s\n", diff_cmd, diff)
+            logger.info("The '%s':\n\n%s\n",
+                        utils.format_command(diff_cmd), diff)
         if utils.ask("OK to commit this"):
             msg = commit_msg % self.data
             msg = self.update_commit_message(msg)

--- a/zest/releaser/svn.py
+++ b/zest/releaser/svn.py
@@ -120,7 +120,7 @@ class Subversion(BaseVersionControl):
             if utils.ask("Shall I create it"):
                 cmd = ['svn', 'mkdir', base + 'tags',
                        '-m', "Creating tags directory."]
-                logger.info("Running %r", cmd)
+                logger.info("Running %r", utils.format_command(cmd))
                 print(execute_command(cmd))
                 tags_name = self._tags_name
                 assert tags_name == 'tags'

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -718,3 +718,31 @@ We print a warning when something is undocumented:
     >>> utils.is_data_documented(data, documentation)
     Checking data dict
     Internal detail: key(s) ['version'] are not documented
+
+
+Formatting commands
+-------------------
+
+You should give a list or tuple as input.
+But let's see what happens with strings:
+
+    >>> print(utils.format_command(''))
+    >>> print(utils.format_command('xyz'))
+    x y z
+
+Do real strings or tuples:
+
+    >>> print(utils.format_command(['x']))
+    x
+    >>> print(utils.format_command(['x', 'y', 'zet']))
+    x y zet
+    >>> print(utils.format_command(('x', 'y', 'zet')))
+    x y zet
+
+Show some real action.
+This should not contain a literal u'...' in the output on Python 2.7,
+but that is hard to test, as we normalize the output to not show it:
+
+    >>> cmd = ['git', 'tag', '1.0', '-m', u'Possibly unicode']
+    >>> print(utils.format_command(cmd))
+    git tag 1.0 -m 'Possibly unicode'

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -674,7 +674,7 @@ def format_command(command):
     args = []
     for arg in command:
         if " " in arg:
-            arg = repr(arg)
+            arg = "'{}'".format(arg)
         args.append(arg)
     return " ".join(args)
 

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -249,7 +249,7 @@ class BaseVersionControl(object):
         setup_lines = setup_lines.split('\n')
         for line_number, line in enumerate(setup_lines):
             if VERSION_PATTERN.search(line):
-                logger.debug("Matching version line found: %r", line)
+                logger.debug("Matching version line found: '%s'", line)
                 if line.startswith(' '):
                     # oh, probably '    version = 1.0,' line.
                     indentation = line.split('version')[0]
@@ -258,17 +258,17 @@ class BaseVersionControl(object):
                 setup_lines[line_number] = good_version
                 utils.write_text_file(
                     'setup.py', '\n'.join(setup_lines), encoding)
-                logger.info("Set setup.py's version to %r", version)
+                logger.info("Set setup.py's version to '%s'", version)
                 return
             if UPPERCASE_VERSION_PATTERN.search(line):
                 # This one only occurs in the first column, so no need to
                 # handle indentation.
-                logger.debug("Matching version line found: %r", line)
+                logger.debug("Matching version line found: '%s'", line)
                 good_version = good_version.upper()
                 setup_lines[line_number] = good_version
                 utils.write_text_file(
                     'setup.py', '\n'.join(setup_lines), encoding)
-                logger.info("Set setup.py's version to %r", version)
+                logger.info("Set setup.py's version to '%s'", version)
                 return
 
         good_version = "version = %s" % version
@@ -277,7 +277,7 @@ class BaseVersionControl(object):
             setup_cfg_lines = setup_cfg_lines.split('\n')
             for line_number, line in enumerate(setup_cfg_lines):
                 if VERSION_PATTERN.search(line):
-                    logger.debug("Matching version line found: %r", line)
+                    logger.debug("Matching version line found: '%s'", line)
                     if line.startswith(' '):
                         indentation = line.split('version')[0]
 


### PR DESCRIPTION
You could get ugly output like this:

    INFO: The '[u'git', u'diff']':

Brackets would be printed in all Python versions.
On Python 2 you could get a `u'unicode'` marker.
It doesn't happen always; it depends on how everything is called.

Hard to say if this catches them all: in the tests we normalize the difference, so you can't see it.