### PR TITLE
Get PyPI password raw, without interpolation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog for zest.releaser
 6.13.6 (unreleased)
 -------------------
 
+- Get PyPI password raw, without interpolation.
+  If you had a password with a percentage sign, you could get an error.
+  Fixes `issue 271 <https://github.com/zestsoftware/zest.releaser/issues/271>`_.
+  [maurits]
+
 - Prevent unclosed files.  Python 3.6 warned about them,
   and PyPy may have more problems with it.
   Fixed several other DeprecationWarnings.  [maurits]

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -219,11 +219,11 @@ class PypiConfig(BaseConfig):
             if self.config.has_option(server, 'username'):
                 username = self._get_text(server, 'username')
             if self.config.has_option(server, 'password'):
-                password = self._get_text(server, 'password')
+                password = self._get_text(server, 'password', raw=True)
         if not username and self.config.has_option('server-login', 'username'):
             username = self._get_text('server-login', 'username')
         if not password and self.config.has_option('server-login', 'password'):
-            password = self._get_text('server-login', 'password')
+            password = self._get_text('server-login', 'password', raw=True)
         return {
             'repository_url': repository_url,
             'username': username,


### PR DESCRIPTION
If you had a password with a percentage sign, you could get an error.
Fixes https://github.com/zestsoftware/zest.releaser/issues/271.

There might be other places where we need to do this, but it is hard to say where interpolation may be useful and where it may be harmful.