### PR TITLE
Encoding config option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog for zest.releaser
 6.13.6 (unreleased)
 -------------------
 
+- Advertise ``setup.cfg`` option ``[zest.releaser] history-file``.
+  Usually zest.releaser can find the correct history or changelog file on its own.
+  But sometimes it may not find anything, or it finds multiple files and selects the wrong one.
+  Then you can set a path here.
+  A ``history_file`` option with an underscore was already read, but not documented.
+  Now we try both a dash and an underscore for good measure.
+  [maurits]
+
 - Use new ``setup.cfg`` option ``[zest.releaser] encoding``.
   Set this to, for example, ``utf-8`` when the encoding of your ``CHANGES.rst``
   file is not determined correctly.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog for zest.releaser
 6.13.6 (unreleased)
 -------------------
 
+- Use new ``setup.cfg`` option ``[zest.releaser] encoding``.
+  Set this to, for example, ``utf-8`` when the encoding of your ``CHANGES.rst``
+  file is not determined correctly.
+  Fixes `issue 264 <https://github.com/zestsoftware/zest.releaser/issues/264>`_.
+  [maurits]
+
 - When inserting changelog entry, check that it conforms to the existing encoding.
   Try to recover if there is a difference, especially when the changelog file
   was ascii and we insert utf-8.  [maurits]

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -165,6 +165,12 @@ date-format = a string
     Note: the % signs should be doubled for compatibility with other tools
     (i.e. pip) that parse setup.cfg using the interpolating ConfigParser.
 
+history-file = a string
+    Default: empty
+    Usually zest.releaser can find the correct history or changelog file on its own.
+    But sometimes it may not find anything, or it finds multiple files and selects the wrong one.
+    Then you can set a path here.
+
 encoding = a string
   Default: empty.
   Set this to, for example, ``utf-8`` when the encoding of your ``CHANGES.rst``

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -165,6 +165,11 @@ date-format = a string
     Note: the % signs should be doubled for compatibility with other tools
     (i.e. pip) that parse setup.cfg using the interpolating ConfigParser.
 
+encoding = a string
+  Default: empty.
+  Set this to, for example, ``utf-8`` when the encoding of your ``CHANGES.rst``
+  file is not determined correctly.
+
 
 Per project options
 -------------------

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -106,10 +106,7 @@ class Basereleaser(object):
         self.data['headings'] = []
         self.data['history_last_release'] = ''
         self.data['history_insert_line_here'] = 0
-        default_location = None
-        config = self.setup_cfg.config
-        if config and config.has_option('zest.releaser', 'history_file'):
-            default_location = config.get('zest.releaser', 'history_file')
+        default_location = self.pypiconfig.history_file()
         fallback_encoding = self.pypiconfig.encoding()
         history_file = self.vcs.history_file(location=default_location)
         self.data['history_file'] = history_file

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -110,13 +110,17 @@ class Basereleaser(object):
         config = self.setup_cfg.config
         if config and config.has_option('zest.releaser', 'history_file'):
             default_location = config.get('zest.releaser', 'history_file')
+        fallback_encoding = self.pypiconfig.encoding()
         history_file = self.vcs.history_file(location=default_location)
         self.data['history_file'] = history_file
         if not history_file:
             logger.warning("No history file found")
             return
         logger.debug("Checking %s", history_file)
-        history_lines, history_encoding = read_text_file(history_file)
+        history_lines, history_encoding = read_text_file(
+            history_file,
+            fallback_encoding=fallback_encoding,
+        )
         history_lines = history_lines.split('\n')
         headings = utils.extract_headings_from_history(history_lines)
         if not headings:
@@ -227,18 +231,33 @@ class Basereleaser(object):
                 'Changelog entry does not have the same encoding (%s) as '
                 'the existing file. This might give problems.', orig_encoding
             )
-            if orig_encoding == 'ascii':
+            config = self.setup_cfg.config
+            fallback_encodings = []
+            if config.has_option('zest.releaser', 'encoding'):
+                encoding = config.get('zest.releaser', 'encoding')
+                if encoding != orig_encoding:
+                    fallback_encodings.append(encoding)
+            encoding = 'utf-8'
+            if encoding != orig_encoding:
+                fallback_encodings.append(encoding)
+            for encoding in fallback_encodings:
                 try:
-                    message.encode('utf-8')
+                    # Note: we do not change the message at this point,
+                    # we only check if an encoding can work.
+                    message.encode(encoding)
                 except UnicodeEncodeError:
                     # Let's continue. There might be a chance that it works.
                     logger.warning(
-                        'Changelog entry is also not utf-8. '
-                        'This will probably fail in a moment.',
-                    )
+                        'Changelog entry is also not %s. ', encoding)
                 else:
-                    logger.debug('Forcing new history_encoding utf-8.')
-                    self.data['history_encoding'] = 'utf-8'
+                    logger.debug('Forcing new history_encoding %s', encoding)
+                    self.data['history_encoding'] = encoding
+                    break
+            else:
+                logger.warning(
+                    'No correct encoding could be determined for writing. '
+                    'This will probably fail in a moment.'
+                )
         lines = []
         prefix = utils.get_list_item(self.data['history_lines'])
         for index, line in enumerate(message.splitlines()):

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -304,6 +304,31 @@ class PypiConfig(BaseConfig):
             return default
         return result
 
+    def encoding(self):
+        """Return encoding to use for text files.
+
+        Mostly the changelog and if needed `setup.py`.
+
+        The encoding cannot always be determined correctly.
+        This setting is a way to fix that.
+        See https://github.com/zestsoftware/zest.releaser/issues/264
+
+        Configure this by adding an ``encoding`` option, either in the
+        package you want to release, or in your ~/.pypirc::
+
+            [zest.releaser]
+            encoding = utf-8
+        """
+        default = ''
+        if self.config is None:
+            return default
+        try:
+            result = self._get_text(
+                'zest.releaser', 'encoding', default=default, raw=True)
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
+
     def create_wheel(self):
         """Should we create a Python wheel for this package?
 

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -304,6 +304,37 @@ class PypiConfig(BaseConfig):
             return default
         return result
 
+    def history_file(self):
+        """Return path of history file.
+
+        Usually zest.releaser can find the correct one on its own.
+        But sometimes it may not find anything, or it finds multiple
+        and selects the wrong one.
+
+        Configure this by adding a ``history-file`` option, either in the
+        package you want to release, or in your ~/.pypirc::
+
+            [zest.releaser]
+            history-file = deep/down/historie.doc
+        """
+        default = ''
+        if self.config is None:
+            return default
+        marker = object()
+        try:
+            result = self._get_text(
+                'zest.releaser', 'history-file', default=marker)
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        if result == marker:
+            # We were reading an underscore instead of a dash at first.
+            try:
+                result = self._get_text(
+                    'zest.releaser', 'history_file', default=default)
+            except (NoSectionError, NoOptionError, ValueError):
+                return default
+        return result
+
     def encoding(self):
         """Return encoding to use for text files.
 

--- a/zest/releaser/tests/vcs.txt
+++ b/zest/releaser/tests/vcs.txt
@@ -162,23 +162,29 @@ source. If a ``__version__`` marker file is specified, that's where we'll look
 and otherwise not.
 
 Create a Python file with ``__version__`` without configuring it. This won't
-change a thing:
+change a thing. We test with a fresh checkout:
 
+    >>> checkout = vcs.BaseVersionControl()
+    >>> checkout.internal_filename = '.marker'
     >>> lines = [
     ...     "import something",
     ...     "__version__ = '2.0'",
     ...     "print('something.else')"]
     >>> writeto('some_file.py', '\n'.join(lines))
+    >>> checkout = vcs.BaseVersionControl()
+    >>> checkout.internal_filename = '.marker'
     >>> checkout.version
     '1.4'
 
 Add a ``setup.cfg`` with a pointer at the Python file and its version gets
-picked up:
+picked up. We need a fresh checkout to pick up the change:
 
     >>> lines = [
     ...     "[zest.releaser]",
     ...     "python-file-with-version = some_file.py"]
     >>> writeto('setup.cfg', '\n'.join(lines))
+    >>> checkout = vcs.BaseVersionControl()
+    >>> checkout.internal_filename = '.marker'
     >>> checkout.get_python_file_version()
     '2.0'
     >>> checkout.version


### PR DESCRIPTION
Fixes issue #264, see discussion there.

I fought a bit with the difference between a few possibilities to read this:
- create a `SetupConfig` object and read the encoding option directly in the calling code (`if setup_config.config.has_option(...)`
- create a `PypiConfig` object, which also reads `setup.cfg` and use a new method `encoding` on that class.

I opted for the second way.
That also meant that I found an undocumented option `history_file` and changed that to use the second way. So I included that in this PR. I kept the commits separate, so you can view them separately if you want.