### PR TITLE
Fixed more ugly printing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,8 @@ Changelog for zest.releaser
 
 - Print commands in a nicer way.
   You could get ugly output like this, especially on Python 2.7:
-  ``INFO: The '[u'git', u'diff']':``
+  ``INFO: The '[u'git', u'diff']':`` or worse:
+  ``Command failed: u"t w i n e ' ' u p l o a d"``.
   [maurits]
 
 - Test compatibility with Python 2.7, 3.4, 3.5. 3.6.

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -203,11 +203,11 @@ class Basereleaser(object):
         else:
             # edit current line
             history_lines[inject_location] = good_heading
-            logger.debug("Set heading from %r to %r.", previous, good_heading)
+            logger.debug("Set heading from '%s' to '%s'.", previous, good_heading)
             history_lines[underline_line] = utils.fix_rst_heading(
                 heading=good_heading,
                 below=history_lines[underline_line])
-            logger.debug("Set line below heading to %r",
+            logger.debug("Set line below heading to '%s'",
                          history_lines[underline_line])
         # Setting history_lines is not needed, except when we have replaced the
         # original instead of changing it.  So just set it.

--- a/zest/releaser/bzr.py
+++ b/zest/releaser/bzr.py
@@ -30,7 +30,7 @@ class Bzr(BaseVersionControl):
         tag_info = execute_command(['bzr', 'tags'])
         tags = [line[:line.find(' ')] for line in tag_info.split('\n')]
         tags = [tag for tag in tags if tag]
-        logger.debug("Available tags: %r", tags)
+        logger.debug("Available tags: '%s'", ' '.join(tags))
         return tags
 
     def prepare_checkout_dir(self, prefix):

--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -40,7 +40,7 @@ class Git(BaseVersionControl):
     def available_tags(self):
         tag_info = execute_command(['git', 'tag'])
         tags = [line for line in tag_info.split('\n') if line]
-        logger.debug("Available tags: %r", tags)
+        logger.debug("Available tags: '%s'", ' '.join(tags))
         return tags
 
     def prepare_checkout_dir(self, prefix):

--- a/zest/releaser/hg.py
+++ b/zest/releaser/hg.py
@@ -33,7 +33,7 @@ class Hg(BaseVersionControl):
         tags = [line[:line.find(' ')] for line in tag_info.split('\n')]
         tags = [tag for tag in tags if tag]
         tags.remove('tip')  # Not functional for us
-        logger.debug("Available tags: %r", tags)
+        logger.debug("Available tags: '%s'", ' '.join(tags))
         return tags
 
     def prepare_checkout_dir(self, prefix):

--- a/zest/releaser/lasttagdiff.py
+++ b/zest/releaser/lasttagdiff.py
@@ -22,7 +22,7 @@ def main():
         found = utils.get_last_tag(vcs)
     name = vcs.name
     full_tag = vcs.tag_url(found)
-    logger.debug("Picked tag %r for %s (currently at %r).",
+    logger.debug("Picked tag '%s' for %s (currently at '%s').",
                  full_tag, name, vcs.version)
     logger.info("Showing differences from the last commit against tag %s",
                 full_tag)

--- a/zest/releaser/lasttaglog.py
+++ b/zest/releaser/lasttaglog.py
@@ -22,7 +22,7 @@ def main():
         found = utils.get_last_tag(vcs)
     name = vcs.name
     full_tag = vcs.tag_url(found)
-    logger.debug("Picked tag %r for %s (currently at %r).",
+    logger.debug("Picked tag '%s' for %s (currently at '%s').",
                  full_tag, name, vcs.version)
     logger.info("Showing log since tag %s and the last commit.",
                 full_tag)

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -101,14 +101,14 @@ class SetupConfig(BaseConfig):
             # Might still be empty.
             value = self._get_text('egg_info', 'tag_build')
             if value:
-                logger.warning("%s has [egg_info] tag_build set to %r",
+                logger.warning("%s has [egg_info] tag_build set to '%s'",
                                self.config_filename, value)
                 bad = True
         # Check 2.
         if self.config.has_option('egg_info', 'tag_svn_revision'):
             if self.config.getboolean('egg_info', 'tag_svn_revision'):
                 value = self._get_text('egg_info', 'tag_svn_revision')
-                logger.warning("%s has [egg_info] tag_svn_revision set to %r",
+                logger.warning("%s has [egg_info] tag_svn_revision set to '%s'",
                                self.config_filename, value)
                 bad = True
         return bad
@@ -522,7 +522,7 @@ class PypiConfig(BaseConfig):
             except (NoSectionError, NoOptionError, ValueError):
                 pass
         if '{version}' not in fmt:
-            print("{version} needs to be part of 'tag-message': %r" % fmt)
+            print("{version} needs to be part of 'tag-message': '%s'" % fmt)
             sys.exit(1)
         return fmt.format(version=version)
 

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -235,7 +235,7 @@ class Releaser(baserelease.Basereleaser):
             print(Fore.RED + "Reason: %s" % response.reason)
         print(Fore.RED + "There were errors or warnings.")
         logger.exception("Package %s has failed.", twine_command)
-        retry = utils.retry_yes_no('twine %s' % twine_command)
+        retry = utils.retry_yes_no(['twine', twine_command])
         if retry:
             logger.info("Retrying.")
             # Reload the pypi config so changes that the user has made to

--- a/zest/releaser/svn.py
+++ b/zest/releaser/svn.py
@@ -122,7 +122,7 @@ class Subversion(BaseVersionControl):
             if utils.ask("Shall I create it"):
                 cmd = ['svn', 'mkdir', base + 'tags',
                        '-m', "Creating tags directory."]
-                logger.info("Running %r", utils.format_command(cmd))
+                logger.info("Running '%s'", utils.format_command(cmd))
                 print(execute_command(cmd))
                 tags_name = self._tags_name
                 assert tags_name == 'tags'
@@ -145,7 +145,7 @@ class Subversion(BaseVersionControl):
         tags = [line.replace('/', '').strip()
                 for line in tag_info.split('\n')]
         tags = [tag for tag in tags if tag]  # filter empty ones
-        logger.debug("Available tags: %r", tags)
+        logger.debug("Available tags: '%s'", ' '.join(tags))
         return tags
 
     def prepare_checkout_dir(self, prefix):

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -185,7 +185,7 @@ def cleanup_version(version):
         if version.find(w) != -1:
             logger.debug("Version indicates development: %s.", version)
             version = version[:version.find(w)].strip()
-            logger.debug("Removing debug indicators: %r", version)
+            logger.debug("Removing debug indicators: '%s'", version)
         version = version.rstrip('.')  # 1.0.dev0 -> 1.0. -> 1.0
     return version
 
@@ -487,13 +487,13 @@ def extract_headings_from_history(history_lines):
                       'version': match.group('version').strip(),
                       'date': match.group('date'.strip())}
             headings.append(result)
-            logger.debug("Found heading: %r", result)
+            logger.debug("Found heading: '%s'", result)
         if alt_match:
             result = {'line': line_number,
                       'version': alt_match.group('version').strip(),
                       'date': alt_match.group('date'.strip())}
             headings.append(result)
-            logger.debug("Found alternative heading: %r", result)
+            logger.debug("Found alternative heading: '%s'", result)
         line_number += 1
     return headings
 
@@ -681,7 +681,7 @@ KNOWN_WARNINGS = [w.lower() for w in KNOWN_WARNINGS]
 def format_command(command):
     # THIS IS INSECURE! DO NOT USE except for directly printing the
     # result.
-    # Poor man's argument qouting, sufficient for user information.
+    # Poor man's argument quoting, sufficient for user information.
     # Used since shlex.quote() does not exist in Python 2.7.
     args = []
     for arg in command:
@@ -735,7 +735,7 @@ def _execute_command(command, input_value=''):
     # ``__command_is_string__`` is string is set, which is meant to be
     # used by the test-suite only (see above).
     assert isinstance(command, (list, tuple)) or __command_is_string__
-    logger.debug("Running command: %r", format_command(command))
+    logger.debug("Running command: '%s'", format_command(command))
     if command[0].startswith(sys.executable):
         env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
         if 'upload' in command or 'register' in command:
@@ -833,7 +833,7 @@ def execute_command(command, allow_retry=False, fail_message=""):
         print(Fore.RED + fail_message)
     retry = retry_yes_no(command)
     if retry:
-        logger.info("Retrying command: %r", format_command(command))
+        logger.info("Retrying command: '%s'", format_command(command))
         return execute_command(command, allow_retry=True)
     # Accept the error, continue with the program.
     return result
@@ -878,14 +878,14 @@ def retry_yes_no(command):
         if input_value:
             input_value = input_value.lower()
             if input_value == 'y' or input_value == 'yes':
-                logger.info("Retrying command: %r", format_command(command))
+                logger.info("Retrying command: '%s'", format_command(command))
                 return True
             if input_value == 'n' or input_value == 'no':
                 # Accept the error, continue with the program.
                 return False
             if input_value == 'q' or input_value == 'quit':
                 raise CommandException(
-                    "Command failed: %r" % format_command(command))
+                    "Command failed: '%s'" % format_command(command))
             # We could print the help/explanation only if the input is
             # '?', or maybe 'h', but if the user input has any other
             # content, it makes sense to explain the options anyway.

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -111,7 +111,7 @@ class BaseVersionControl(object):
         for line in lines:
             match = UNDERSCORED_VERSION_PATTERN.search(line)
             if match:
-                logger.debug("Matching __version__ line found: %r", line)
+                logger.debug("Matching __version__ line found: '%s'", line)
                 line = line.lstrip('__version__').strip()
                 line = line.lstrip('=').strip()
                 line = line.replace('"', '').replace("'", "")
@@ -216,7 +216,7 @@ class BaseVersionControl(object):
                 lines[index] = "__version__ = '%s'" % version
         contents = '\n'.join(lines)
         utils.write_text_file(filename, contents, encoding)
-        logger.info("Set __version__ in %s to %r", filename, version)
+        logger.info("Set __version__ in %s to '%s'", filename, version)
 
     def _update_version(self, version):
         """Find out where to change the version and change it.
@@ -242,7 +242,7 @@ class BaseVersionControl(object):
                                      self.get_version_txt_version()):
                 with open(versionfile, 'w') as f:
                     f.write(version + '\n')
-                logger.info("Changed %s to %r", versionfile, version)
+                logger.info("Changed %s to '%s'", versionfile, version)
                 return
 
         good_version = "version = '%s'" % version
@@ -287,7 +287,7 @@ class BaseVersionControl(object):
                     setup_cfg_lines[line_number] = good_version
                     utils.write_text_file(
                         'setup.cfg', '\n'.join(setup_cfg_lines), encoding)
-                    logger.info("Set setup.cfg's version to %r", version)
+                    logger.info("Set setup.cfg's version to '%s'", version)
                     return
 
         logger.error(


### PR DESCRIPTION
Printing the twine command for retrying would give this:

    Command failed: "t w i n e ' ' u p l o a d"

And with Python2.7, in this and various other spots, a ``u'unicode'`` marker would be visible. This is because several things were logged with ``%r``.

In most cases, the only reason for the raw format was so that it was clear where the command started and ended, because it would be enclosed in 'quotes'. But for unicode this becomes u'quotes', which is ugly. Note that we use `from __future__ import unicode_literals` so all strings in the code are actually unicode.

So instead of `%r` we now quote it ourselves with `'%s'`.