### PR TITLE
Towncrier support [do not merge]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog for zest.releaser
 6.14.1 (unreleased)
 -------------------
 
+- Added keys ``update_history`` and ``update_version`` in prerelease
+  and postrelease data.  Add-ons can use this to tell ``zest.releaser``
+  (and other add-ons) to not touch the history or the version number.
+  [maurits]
+
 - Declared ``requests`` dependency.
   Declared ``zope.testing`` test dependency.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for zest.releaser
 6.14.1 (unreleased)
 -------------------
 
+- Added towncrier hooks for updating the changelog with news fragments.
+  [maurits]
+
 - Added keys ``update_history`` and ``update_version`` in prerelease
   and postrelease data.  Add-ons can use this to tell ``zest.releaser``
   (and other add-ons) to not touch the history or the version number.

--- a/setup.py
+++ b/setup.py
@@ -110,5 +110,5 @@ setup(name='zest.releaser',
               'zest.releaser.preparedocs:prepare_entrypoint_documentation',
               ],
 
-          },
+      },
       )

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ setup(name='zest.releaser',
               'check-manifest',
               'pyroma',
               'readme_renderer',
+              'toml',
+              'towncrier',
               'wheel',
               ],
           'test': [
@@ -91,6 +93,8 @@ setup(name='zest.releaser',
           # our entry point implementation.
           'zest.releaser.prereleaser.middle': [
               'datacheck = zest.releaser.prerelease:datacheck',
+              # Call towncrier to update the changelog with newsfragments:
+              'call_towncrier = zest.releaser.towncrier_hooks:call_towncrier',
               ],
           'zest.releaser.releaser.middle': [
               'datacheck = zest.releaser.release:datacheck',
@@ -108,6 +112,15 @@ setup(name='zest.releaser',
           'zest.releaser.prereleaser.before': [
               'preparedocs = ' +
               'zest.releaser.preparedocs:prepare_entrypoint_documentation',
+              # Check if towncrier is available and configured:
+              'check_towncrier = zest.releaser.towncrier_hooks:check_towncrier',
+              ],
+          'zest.releaser.postreleaser.before': [
+              # Towncrier for news.
+              # We only need to check if towncrier is available and
+              # configured for this project.
+              # Then the history should not be changed.
+              'check_towncrier = zest.releaser.towncrier_hooks:check_towncrier',
               ],
 
       },

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -22,6 +22,8 @@ DATA.update({
     'dev_version_template': 'Template for development version number',
     'development_marker': 'String to be appended to version after postrelease',
     'new_version': 'New version, without development marker (so 1.1)',
+    'update_history': 'Should zest.releaser update the history file?',
+    'update_version': 'Should zest.releaser update the version file?',
 })
 
 
@@ -40,6 +42,8 @@ class Postreleaser(baserelease.Basereleaser):
             dev_version_template=DEV_VERSION_TEMPLATE,
             development_marker=self.pypiconfig.development_marker(),
             history_header=HISTORY_HEADER,
+            update_history=True,
+            update_version=True,
         ))
 
     def prepare(self):
@@ -52,9 +56,12 @@ class Postreleaser(baserelease.Basereleaser):
 
     def execute(self):
         """Make the changes and offer a commit"""
-        self._write_version()
-        self._change_header(add=True)
-        self._write_history()
+        if self.data['update_version']:
+            self._write_version()
+        if self.data['update_history']:
+            self._change_header(add=True)
+            self._write_history()
+        # Always ask to commit, because an entrypoint may have made changes.
         self._diff_and_commit()
         self._push()
 

--- a/zest/releaser/prerelease.py
+++ b/zest/releaser/prerelease.py
@@ -15,10 +15,12 @@ HISTORY_HEADER = '%(new_version)s (%(today)s)'
 PRERELEASE_COMMIT_MSG = 'Preparing release %(new_version)s'
 
 # Documentation for self.data.  You get runtime warnings when something is in
-# self.data that is not in this list.  Embarrasment-driven documentation!
+# self.data that is not in this list.  Embarrassment-driven documentation!
 DATA = baserelease.DATA.copy()
 DATA.update({
     'today': 'Date string used in history header',
+    'update_history': 'Should zest.releaser update the history file?',
+    'update_version': 'Should zest.releaser update the version file?',
 })
 
 
@@ -37,6 +39,8 @@ class Prereleaser(baserelease.Basereleaser):
             commit_msg=PRERELEASE_COMMIT_MSG,
             history_header=HISTORY_HEADER,
             today=datetime.datetime.today().strftime(date_format),
+            update_history=True,
+            update_version=True,
         ))
 
     def prepare(self):
@@ -48,25 +52,38 @@ class Prereleaser(baserelease.Basereleaser):
             logger.debug("Recommended files check failed.")
             sys.exit(1)
         # Grab current version.
+        # It seems useful to do this even when we will not update the version.
         self._grab_version(initial=True)
         # Grab current history.
+        # It seems useful to do this even when we will not update the history.
         self._grab_history()
-        # Print changelog for this release.
-        print("Changelog entries for version {0}:\n".format(
-            self.data['new_version']))
-        print(self.data.get('history_last_release'))
+        if self.data['update_history']:
+            # Print changelog for this release.
+            print("Changelog entries for version {0}:\n".format(
+                self.data['new_version']))
+            print(self.data.get('history_last_release'))
         # Grab and set new version.
         self._grab_version()
-        # Look for unwanted 'Nothing changed yet' in latest header.
-        self._check_nothing_changed()
-        # Look for required text under the latest header.
-        self._check_required()
+        if self.data['update_history']:
+            # Look for unwanted 'Nothing changed yet' in latest header.
+            self._check_nothing_changed()
+            # Look for required text under the latest header.
+            self._check_required()
 
     def execute(self):
         """Make the changes and offer a commit"""
-        self._change_header()
-        self._write_version()
-        self._write_history()
+        if self.data['update_history']:
+            self._change_header()
+        if self.data['update_version']:
+            self._write_version()
+        if self.data['update_history']:
+            self._write_history()
+        # If update_history and update_version are both False,
+        # we will not have changed anything ourselves,
+        # but an entry point may have made changes without committing them.
+        # An empty commit is fine.
+        # Maybe _diff_and_commit could be made smarter, seeing that there
+        # is no diff.  But that may be hard to reliably do.
         self._diff_and_commit()
 
     def _grab_version(self, initial=False):

--- a/zest/releaser/towncrier_hooks.py
+++ b/zest/releaser/towncrier_hooks.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from zest.releaser import utils
+import logging
+import os
+import pkg_resources
+import toml
+
+# towncrier might become a conditional dependency of zest.releaser,
+# for example in the recommended list.
+# If we split this into a separate package, it should be a hard dependency.
+try:
+    pkg_resources.get_distribution('towncrier')
+except pkg_resources.DistributionNotFound:
+    HAS_TOWNCRIER = False
+else:
+    HAS_TOWNCRIER = True
+
+
+logger = logging.getLogger('towncrier_hooks')
+TOWNCRIER_MARKER = '_towncrier_applicable'
+TOWNCRIER_CONFIG_FILE = 'pyproject.toml'
+
+
+def load_config():
+    fn = os.path.join(TOWNCRIER_CONFIG_FILE)
+    if not os.path.exists(fn):
+        return
+    with open(fn, 'r') as conffile:
+        config = toml.load(conffile)
+    if 'tool' not in config:
+        return
+    config = config['tool']
+    if 'towncrier' not in config:
+        return
+    config = config['towncrier']
+    # Currently we need 'package' in the config.
+    if 'package' not in config:
+        logger.error(
+            "The [tool.towncrier] section of %s "
+            "has no required 'package' key.", TOWNCRIER_CONFIG_FILE)
+        return
+    return True
+
+
+def _check_towncrier():
+    # First check if the towncrier tool is available.
+    # towncrier might be on the PATH but not importable or the other way around.
+    # So could be tricky to know for sure that it is available.
+    # Maybe call 'towncrier --help' and see if that gives an error.
+    if not HAS_TOWNCRIER:
+        return False
+    # Read pyproject.toml with the toml package.
+    if not load_config():
+        return False
+    return True
+
+
+def check_towncrier(data):
+    if TOWNCRIER_MARKER in data:
+        # We have already been called.
+        return data[TOWNCRIER_MARKER]
+    if not data['update_history']:
+        # Someone has instructed zest.releaser to not update the history,
+        # and it was not us, because our marker was not set,
+        # so we should not update the history either.
+        logger.debug(
+            'update_history is already False, so towncrier will not be run.')
+        data[TOWNCRIER_MARKER] = False
+        return False
+    # Check if towncrier should be applied.
+    result = _check_towncrier()
+    if result:
+        logger.debug('towncrier should be applied.')
+        # zest.releaser should not update the history.
+        # towncrier will do that.
+        data['update_history'] = False
+    else:
+        logger.debug('towncrier cannot be applied.')
+    data[TOWNCRIER_MARKER] = result
+    return result
+
+
+def call_towncrier(data):
+    """Entrypoint: run towncrier when applicable."""
+    if not check_towncrier(data):
+        return
+    cmd = ['towncrier', '--version', data['new_version'], '--yes']
+    # We would like to pass ['--package' 'package name'] as well,
+    # but that is not yet in a release of towncrier.
+    logger.info(
+        'Running command to update news: %s', utils.format_command(cmd))
+    print(utils.execute_command(cmd))
+    # towncrier stages the changes with git,
+    # which BTW means that our plugin requires git.
+    logger.info('The staged git changes are:')
+    print(utils.execute_command(['git', 'diff', '--cached']))
+    logger.info(
+        'towncrier has finished updating the history file '
+        'and has staged the above changes in git.')

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -580,8 +580,9 @@ def is_data_documented(data, documentation=None):
     if TESTMODE:
         # Hack for testing to prove entry point is being called.
         print("Checking data dict")
-    undocumented = [key for key in data
-                    if key not in documentation]
+    undocumented = [
+        key for key in data
+        if key not in documentation and not key.startswith('_')]
     if undocumented:
         print('Internal detail: key(s) %s are not documented' % undocumented)
 


### PR DESCRIPTION
For some Plone packages we want to start using [`towncrier`](https://pypi.org/project/towncrier/) to handle updating `CHANGES.rst`, just like for example [`pip` does](https://pip.pypa.io/en/latest/development/#adding-a-news-entry). For explanation, see https://github.com/plone/plone.releaser/issues/17. (`plone.releaser` is a wrapper around `zest.releaser` that we use when creating releases for Plone packages.)

This may need to be done in a separate small plugin. But it needs a few changes in `zest.releaser`. Mainly: when `towncrier` updates the `CHANGES.rst`, `zest.releaser` should not touch that file at all.

So I made two commits:
- one with a few minor changes in `zest.releaser`: 39b465ed642b7420b0bfe5e0d79b567978b5b605
- one with the hooks for calling `towncrier`: acd9b97a02fb681c0a0d72aaa253a52516aa8a90

The second part may need to be moved to a separate plugin, and I am happy to do so. It *could* be okay to include it in `zest.releaser`, and it at least makes it easier to try out this PR.

I have used this code to make release [4.0.1](https://github.com/collective/collective.recipe.backup/tree/4.0.1) of [`collective.recipe.backup`](https://github.com/collective/collective.recipe.backup). Most important are these commits:
- [prerelease](https://github.com/collective/collective.recipe.backup/commit/935c48629b4b71d1b98d573d7adbaaf6825d01b9)
- [postrelease](https://github.com/collective/collective.recipe.backup/commit/3482b0ed601e8916a51ffd623458374821576e0a)

So:
- review welcome on the first commit with the minor zest.releaser changes
- feedback welcome on the towncrier hooks and whether that should be a separate plugin