### PR TITLE
Added key update_history in data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog for zest.releaser
 6.14.1 (unreleased)
 -------------------
 
+- Added key ``update_history`` in prerelease and postrelease data.
+  Plugins can use this to tell ``zest.releaser`` (and other plugins)
+  to not touch the history, presumably because the plugin handles it.
+  [maurits]
+
 - Declared ``requests`` dependency.
   Declared ``zope.testing`` test dependency.
   [maurits]

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -22,6 +22,7 @@ DATA.update({
     'dev_version_template': 'Template for development version number',
     'development_marker': 'String to be appended to version after postrelease',
     'new_version': 'New version, without development marker (so 1.1)',
+    'update_history': 'Should zest.releaser update the history file?',
 })
 
 
@@ -40,6 +41,7 @@ class Postreleaser(baserelease.Basereleaser):
             dev_version_template=DEV_VERSION_TEMPLATE,
             development_marker=self.pypiconfig.development_marker(),
             history_header=HISTORY_HEADER,
+            update_history=True,
         ))
 
     def prepare(self):
@@ -53,8 +55,9 @@ class Postreleaser(baserelease.Basereleaser):
     def execute(self):
         """Make the changes and offer a commit"""
         self._write_version()
-        self._change_header(add=True)
-        self._write_history()
+        if self.data['update_history']:
+            self._change_header(add=True)
+            self._write_history()
         self._diff_and_commit()
         self._push()
 

--- a/zest/releaser/prerelease.py
+++ b/zest/releaser/prerelease.py
@@ -15,10 +15,11 @@ HISTORY_HEADER = '%(new_version)s (%(today)s)'
 PRERELEASE_COMMIT_MSG = 'Preparing release %(new_version)s'
 
 # Documentation for self.data.  You get runtime warnings when something is in
-# self.data that is not in this list.  Embarrasment-driven documentation!
+# self.data that is not in this list.  Embarrassment-driven documentation!
 DATA = baserelease.DATA.copy()
 DATA.update({
     'today': 'Date string used in history header',
+    'update_history': 'Should zest.releaser update the history file?',
 })
 
 
@@ -37,6 +38,7 @@ class Prereleaser(baserelease.Basereleaser):
             commit_msg=PRERELEASE_COMMIT_MSG,
             history_header=HISTORY_HEADER,
             today=datetime.datetime.today().strftime(date_format),
+            update_history=True,
         ))
 
     def prepare(self):
@@ -50,23 +52,28 @@ class Prereleaser(baserelease.Basereleaser):
         # Grab current version.
         self._grab_version(initial=True)
         # Grab current history.
+        # It seems useful to do this even when we will not update the history.
         self._grab_history()
-        # Print changelog for this release.
-        print("Changelog entries for version {0}:\n".format(
-            self.data['new_version']))
-        print(self.data.get('history_last_release'))
+        if self.data['update_history']:
+            # Print changelog for this release.
+            print("Changelog entries for version {0}:\n".format(
+                self.data['new_version']))
+            print(self.data.get('history_last_release'))
         # Grab and set new version.
         self._grab_version()
-        # Look for unwanted 'Nothing changed yet' in latest header.
-        self._check_nothing_changed()
-        # Look for required text under the latest header.
-        self._check_required()
+        if self.data['update_history']:
+            # Look for unwanted 'Nothing changed yet' in latest header.
+            self._check_nothing_changed()
+            # Look for required text under the latest header.
+            self._check_required()
 
     def execute(self):
         """Make the changes and offer a commit"""
-        self._change_header()
+        if self.data['update_history']:
+            self._change_header()
         self._write_version()
-        self._write_history()
+        if self.data['update_history']:
+            self._write_history()
         self._diff_and_commit()
 
     def _grab_version(self, initial=False):

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -580,8 +580,9 @@ def is_data_documented(data, documentation=None):
     if TESTMODE:
         # Hack for testing to prove entry point is being called.
         print("Checking data dict")
-    undocumented = [key for key in data
-                    if key not in documentation]
+    undocumented = [
+        key for key in data
+        if key not in documentation and not key.startswith('_')]
     if undocumented:
         print('Internal detail: key(s) %s are not documented' % undocumented)
 


### PR DESCRIPTION
This replaces PR #279.

This is in prerelease and postrelease data.
Plugins can use this to tell `zest.releaser` (and other plugins) to not touch the history, presumably because the plugin itself handles it.

Default value is True: do update history.

The `update_history` key will be used by a towncrier plugin that will update the changelog with news fragments.

The towncrier plugin will add an internal data key `_towncrier_applicable`.
With this, you would get this warning when running zest.releaser:

    Internal detail: key(s) ['_towncrier_applicable'] are not documented

So I have changed this internal check to allow undocumented data keys when they start with underscore.