### PR TITLE
Use pypi.org, especially when checking if a package is on PyPI.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog for zest.releaser
 6.14.1 (unreleased)
 -------------------
 
+- Use pypi.org, especially when checking if a package is on PyPI.
+  Fixes `issue #281 <https://github.com/zestsoftware/zest.releaser/issues/281>`_.
+  [maurits]
+
 - Added key ``update_history`` in prerelease and postrelease data.
   Plugins can use this to tell ``zest.releaser`` (and other plugins)
   to not touch the history, presumably because the plugin handles it.
@@ -594,4 +598,4 @@ Fixes:
 
 .. # Note: for older changes see ``doc/sources/changelog.rst``.
 
-.. _twine: https://pypi.python.org/pypi/twine
+.. _twine: https://pypi.org/project/twine

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ First the three most important links:
 - The full documentation is at `zestreleaser.readthedocs.io
   <http://zestreleaser.readthedocs.io>`_.
 
-- We're `on PyPI <http://pypi.org/project/zest.releaser>`_, so we're only
+- We're `on PyPI <https://pypi.org/project/zest.releaser>`_, so we're only
   an ``pip install zest.releaser`` away from installation on your computer.
 
 - The code is at `github.com/zestsoftware/zest.releaser

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ First the three most important links:
 - The full documentation is at `zestreleaser.readthedocs.io
   <http://zestreleaser.readthedocs.io>`_.
 
-- We're `on PyPI <http://pypi.python.org/pypi/zest.releaser>`_, so we're only
+- We're `on PyPI <http://pypi.org/project/zest.releaser>`_, so we're only
   an ``pip install zest.releaser`` away from installation on your computer.
 
 - The code is at `github.com/zestsoftware/zest.releaser
@@ -106,12 +106,12 @@ of ``zest.releaser`` users:
 - twine_ for secure uploading via https to pypi. Plain setuptools doesn't
   support this.
 
-.. _wheel: https://pypi.python.org/pypi/wheel
-.. _`check-manifest`: https://pypi.python.org/pypi/check-manifest
-.. _pyroma: https://pypi.python.org/pypi/pyroma
-.. _chardet: https://pypi.python.org/pypi/chardet
-.. _readme: https://pypi.python.org/pypi/readme
-.. _twine: https://pypi.python.org/pypi/twine
+.. _wheel: https://pypi.org/project/wheel
+.. _`check-manifest`: https://pypi.org/project/check-manifest
+.. _pyroma: https://pypi.org/project/pyroma
+.. _chardet: https://pypi.org/project/chardet
+.. _readme: https://pypi.org/project/readme
+.. _twine: https://pypi.org/project/twine
 
 
 Installation

--- a/doc/source/entrypoints.rst
+++ b/doc/source/entrypoints.rst
@@ -51,7 +51,7 @@ like this should do the trick::
             return
         ...
 
-.. _`gocept.zestreleaser.customupload`: http://pypi.org/project/gocept.zestreleaser.customupload
+.. _`gocept.zestreleaser.customupload`: https://pypi.org/project/gocept.zestreleaser.customupload
 
 
 Entry point specification

--- a/doc/source/entrypoints.rst
+++ b/doc/source/entrypoints.rst
@@ -51,7 +51,7 @@ like this should do the trick::
             return
         ...
 
-.. _`gocept.zestreleaser.customupload`: http://pypi.python.org/pypi/gocept.zestreleaser.customupload
+.. _`gocept.zestreleaser.customupload`: http://pypi.org/project/gocept.zestreleaser.customupload
 
 
 Entry point specification

--- a/doc/source/uploading.rst
+++ b/doc/source/uploading.rst
@@ -7,7 +7,7 @@ zest.releaser basically executes the command ``python setup.py sdist`` and does 
 ``python setup.py sdist upload``.
 
 For safety reasons zest.releaser will *only* offer to upload your package to
-https://pypi.python.org when the package is already registered there.  If this
+https://pypi.org when the package is already registered there.  If this
 is not the case yet, you get a confirmation question whether you want to
 register a new package with ``twine register``.
 
@@ -26,17 +26,10 @@ has your pypi login credentials.  This may contain alternative servers too::
   [distutils]
   index-servers =
     pypi
-    warehouse
     local
 
   [pypi]
-  # default repository is pypi.python.org
-  username:maurits
-  password:secret
-
-  [warehouse]
-  # This is the successor for PyPI, which you can/should already use.
-  repository:https://upload.pypi.org/legacy/
+  # default repository is pypi.org/legacy/
   username:maurits
   password:secret
 
@@ -71,7 +64,7 @@ tag for tweaks or pypi/distutils server upload.  We could add some extra
 checks to see if that is really needed, but someone who does not have
 index-servers listed, may still want to use an entry point like
 `gocept.zestreleaser.customupload
-<http://pypi.python.org/pypi/gocept.zestreleaser.customupload>`_ to do
+<http://pypi.org/project/gocept.zestreleaser.customupload>`_ to do
 uploading, or do some manual steps first before uploading.
 
 Since version 6.8, zest.releaser by default no longer *registers* a new package, but only uploads it.
@@ -101,7 +94,7 @@ Package Index, because it is safer: it uses ``https`` for uploading.
 Since version 4.0 we already prefered it if it was available, but it
 is now a core dependency, installed automatically.
 
-.. _twine: https://pypi.python.org/pypi/twine
+.. _twine: https://pypi.org/project/twine
 
 Since version 6.6.6 we use it in a way that should work with ``twine``
 1.6.0 and higher, including future versions.
@@ -221,7 +214,7 @@ In general, if you are missing files in the uploaded package, the best
 is to put a proper ``MANIFEST.in`` file next to your ``setup.py``.
 See `zest.pocompile`_ for an example.
 
-.. _`zest.pocompile`: http://pypi.python.org/pypi/zest.pocompile
+.. _`zest.pocompile`: http://pypi.org/project/zest.pocompile
 
 
 Running automatically without input

--- a/doc/source/uploading.rst
+++ b/doc/source/uploading.rst
@@ -29,7 +29,7 @@ has your pypi login credentials.  This may contain alternative servers too::
     local
 
   [pypi]
-  # default repository is pypi.org/legacy/
+  # default repository is https://upload.pypi.org/legacy/
   username:maurits
   password:secret
 
@@ -64,7 +64,7 @@ tag for tweaks or pypi/distutils server upload.  We could add some extra
 checks to see if that is really needed, but someone who does not have
 index-servers listed, may still want to use an entry point like
 `gocept.zestreleaser.customupload
-<http://pypi.org/project/gocept.zestreleaser.customupload>`_ to do
+<https://pypi.org/project/gocept.zestreleaser.customupload>`_ to do
 uploading, or do some manual steps first before uploading.
 
 Since version 6.8, zest.releaser by default no longer *registers* a new package, but only uploads it.
@@ -214,7 +214,7 @@ In general, if you are missing files in the uploaded package, the best
 is to put a proper ``MANIFEST.in`` file next to your ``setup.py``.
 See `zest.pocompile`_ for an example.
 
-.. _`zest.pocompile`: http://pypi.org/project/zest.pocompile
+.. _`zest.pocompile`: https://pypi.org/project/zest.pocompile
 
 
 Running automatically without input

--- a/zest/releaser/release.py
+++ b/zest/releaser/release.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 def package_in_pypi(package):
     """Check whether the package is registered on pypi"""
-    url = 'https://pypi.python.org/simple/%s' % package
+    url = 'https://pypi.org/simple/%s' % package
     try:
         urllib2.urlopen(url)
         return True

--- a/zest/releaser/tests/functional.py
+++ b/zest/releaser/tests/functional.py
@@ -44,7 +44,7 @@ def setup(test):
     def _make_mock_urlopen(mock_pypi_available):
         def _mock_urlopen(url):
             # print "Mock opening", url
-            package = url.replace('https://pypi.python.org/simple/', '')
+            package = url.replace('https://pypi.org/simple/', '')
             if package not in mock_pypi_available:
                 raise HTTPError(
                     url, 404,


### PR DESCRIPTION
One real code change, the rest is documentation or tests.

Fixes issue #281.