### PR TITLE
Use Annotated Tags in Git

### DIFF
--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -79,7 +79,7 @@ class Git(BaseVersionControl):
         return ['git', 'log', '%s..HEAD' % version]
 
     def cmd_create_tag(self, version, message, sign=False):
-        cmd = ['git', 'tag', version, '-m', message]
+        cmd = ['git', 'tag', version, '-a', '-m', message]
         if sign:
             cmd.append("--sign")
         if os.path.isdir('.git/svn'):


### PR DESCRIPTION
According to [git's own documentation](https://git-scm.com/docs/git-tag):

> Annotated tags are meant for release while lightweight tags are meant for private or temporary object labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight tags by default.