### PR TITLE
WIP: Fix for #297: bytes+int problem on python 3 when detecting encodings

### DIFF
--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -746,3 +746,26 @@ but that is hard to test, as we normalize the output to not show it:
     >>> cmd = ['git', 'tag', '1.0', '-m', u'Possibly unicode']
     >>> print(utils.format_command(cmd))
     git tag 1.0 -m 'Possibly unicode'
+
+
+Reading text files
+------------------
+
+When reading text files, reliable encoding handling is a pain. Did anyone say
+"corner cases"?
+
+There once was a bug with python 3. ``b'example'[0] gives back an integer
+instead of an ``b'e'``. We had to compensate for that so that the following
+example works:
+
+    >>> import os
+    >>> import tempfile
+    >>> _, example_filename = tempfile.mkstemp()
+    >>> _ = open(example_filename, 'wb').write(
+    ...     '# -*- coding: utf-8 -*-\nblaá'.encode('utf-8'))
+    >>> contents, encoding = utils.read_text_file(example_filename)
+    >>> 'bla' in contents
+    True
+    >>> encoding
+    'utf-8'
+    >>> os.remove(example_filename)  # cleanup


### PR DESCRIPTION
I added a test that demonstrates the #297 problem. I get this expected traceback locally:

    Traceback (most recent call last):
      File "/home/reinout/.pyenv/versions/3.7.1/lib/python3.7/doctest.py", line 1329, in __run
        compileflags, 1), test.globs)
      File "<doctest utils.txt[211]>", line 1, in <module>
        contents, encoding = utils.read_text_file(example_filename)
      File "/home/reinout/opensource/zest.releaser/zest/releaser/utils.py", line 163, in read_text_file
        coding += data[pos]
    TypeError: can't concat int to bytes

Work in progress.