### PR TITLE
Retain quote style for version strings in setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 6.15.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- We retain the existing quoting style for the ``version='1.0'`` in
+  ``setup.py`` files. The "black" code formatting prefers double quotes and
+  zest.releaser by default wrote single quotes.
 
 
 6.15.3 (2018-12-03)

--- a/zest/releaser/tests/vcs.txt
+++ b/zest/releaser/tests/vcs.txt
@@ -280,3 +280,27 @@ version in setup.cfg:
     ...     print(f.read())
     [metadata]
     version = 1.2
+
+Setup.py with a double-quoted version, as prefered by the 'black' code
+formatter:
+
+    >>> doublequotedversionproject = os.path.join(tempdir, 'dqv')
+    >>> os.mkdir(doublequotedversionproject)
+    >>> os.chdir(doublequotedversionproject)
+    >>> lines = [
+    ...     "from setuptools import setup",
+    ...     "setup(name='urgh',",
+    ...     "      version=\"1.0\",",
+    ...     ")"]
+    >>> writeto('setup.py', '\n'.join(lines))
+    >>> checkout.version = '1.2'
+
+The version line should have retained its double quotes, otherwise black would
+have to change it back again:
+
+    >>> with open('setup.py') as f:
+    ...     print(f.read())
+    from setuptools import setup
+    setup(name='urgh',
+          version="1.2",
+    )

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -267,6 +267,8 @@ class BaseVersionControl(object):
                     indentation = line.split('version')[0]
                     # Note: no spaces around the '='.
                     good_version = indentation + "version='%s'," % version
+                if '"' in line:
+                    good_version = good_version.replace("'", '"')
                 setup_lines[line_number] = good_version
                 utils.write_text_file(
                     'setup.py', '\n'.join(setup_lines), encoding)
@@ -277,6 +279,8 @@ class BaseVersionControl(object):
                 # handle indentation.
                 logger.debug("Matching version line found: '%s'", line)
                 good_version = good_version.upper()
+                if '"' in line:
+                    good_version = good_version.replace("'", '"')
                 setup_lines[line_number] = good_version
                 utils.write_text_file(
                     'setup.py', '\n'.join(setup_lines), encoding)


### PR DESCRIPTION
This fixes #301.
The first commit demonstrates the issue. After that one fails, the second commit fixes it.