### PR TITLE
Comparing versions as versions, not strings (fixes #299)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Changelog for zest.releaser
 - We retain the existing quoting style for the ``version='1.0'`` in
   ``setup.py`` files. The "black" code formatting prefers double quotes and
   zest.releaser by default wrote single quotes.
+  [reinout]
+
+- Fix for `issue #299 <https://github.com/zestsoftware/zest.releaser/issues/299>`_:
+  bumpversion now also compares versions numerically instead of as a string,
+  so ``2.9 < 2.10`` is now true.
+  [reinout]
 
 
 6.15.3 (2018-12-03)

--- a/zest/releaser/bumpversion.py
+++ b/zest/releaser/bumpversion.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import logging
 import sys
 
+from pkg_resources import parse_version
 from zest.releaser import baserelease
 from zest.releaser import utils
 
@@ -102,7 +103,8 @@ class BumpVersion(baserelease.Basereleaser):
             )
             minimum_version = utils.suggest_version(
                 last_tag_version, **params)
-            if minimum_version <= original_version:
+            if parse_version(minimum_version) <= parse_version(
+                    utils.cleanup_version(original_version)):
                 print("No version bump needed.")
                 sys.exit(0)
             # A bump is needed.  Get suggestion for next version.

--- a/zest/releaser/tests/bumpversion.txt
+++ b/zest/releaser/tests/bumpversion.txt
@@ -38,23 +38,23 @@ error is ugly, but in practice it looks fine, saying no bump is needed.
 So first run the fullrelease:
 
     >>> from zest.releaser import fullrelease
-    >>> utils.test_answer_book.set_answers(['', '', '', '2.3.4', '', '', '', '', '', '', ''])
+    >>> utils.test_answer_book.set_answers(['', '', '', '2.9.4', '', '', '', '', '', '', ''])
     >>> fullrelease.main()
     Question...
     Question: Enter version [0.1]:
-    Our reply: 2.3.4
+    Our reply: 2.9.4
     ...
     >>> svnhead('CHANGES.txt')
     Changelog of tha.example
     ========================
     <BLANKLINE>
-    2.3.5 (unreleased)
+    2.9.5 (unreleased)
     ------------------
     >>> svnhead('setup.py')
     from setuptools import setup, find_packages
     import os.path
     <BLANKLINE>
-    version = '2.3.5.dev0'
+    version = '2.9.5.dev0'
 
 Try bumpversion again.  The first time we again get an error because
 no version bump is needed: our current version is already higher than
@@ -72,9 +72,9 @@ Now a feature bump::
     >>> sys.argv[1:] = ['--feature']
     >>> bumpversion.main()
     Checking version bump for feature release.
-    Last tag: 2.3.4
-    Current version: 2.3.5.dev0
-    Question: Enter version [2.4.0.dev0]:
+    Last tag: 2.9.4
+    Current version: 2.9.5.dev0
+    Question: Enter version [2.10.0.dev0]:
     Our reply: <ENTER>
     Checking data dict
     Question: OK to commit this (Y/n)?
@@ -83,13 +83,13 @@ Now a feature bump::
     from setuptools import setup, find_packages
     import os.path
     <BLANKLINE>
-    version = '2.4.0.dev0'
+    version = '2.10.0.dev0'
     >>> svnhead('CHANGES.txt')
     Changelog of tha.example
     ========================
     <BLANKLINE>
-    2.4.0 (unreleased)
-    ------------------
+    2.10.0 (unreleased)
+    -------------------
 
 Now a breaking bump, and for this test we explicitly remove the dev marker::
 
@@ -97,8 +97,8 @@ Now a breaking bump, and for this test we explicitly remove the dev marker::
     >>> sys.argv[1:] = ['--breaking']
     >>> bumpversion.main()
     Checking version bump for breaking release.
-    Last tag: 2.3.4
-    Current version: 2.4.0.dev0
+    Last tag: 2.9.4
+    Current version: 2.10.0.dev0
     Question: Enter version [3.0.0.dev0]:
     Our reply: 3.0.0
     Checking data dict


### PR DESCRIPTION
This prevents `1.10` from being less than `1.9`

There's no separate test as the test setup drives me mad. The existing functionality still works like a charm, though.