### PR TITLE
Use Ubuntu 16.04 (xenial) for testing on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+dist: xenial
+
 language: python
 python:
   - 2.7


### PR DESCRIPTION
As recommenced by https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments