### PR TITLE
Let bumpversion respect the update_history data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 6.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Let bumpversion respect the ``update_history`` data.
+  Fixes `issue 310 <https://github.com/zestsoftware/zest.releaser/issues/310>`_.
+  [maurits]
 
 
 6.16.0 (2019-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog for zest.releaser
 6.16.1 (unreleased)
 -------------------
 
-- Let bumpversion respect the ``update_history`` data.
+- Better support for ``zestreleaser.towncrier`` (and similar extensions):
+  the update_history setting is now also respected by the ``bumpversion`` command.
   Fixes `issue 310 <https://github.com/zestsoftware/zest.releaser/issues/310>`_.
   [maurits]
 

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -44,6 +44,7 @@ DATA = {
         'Text that must be present in the changelog. Can be a string or a '
         'list, for example ["New:", "Fixes:"]. For a list, only one of them '
         'needs to be present.'),
+    'update_history': 'Should zest.releaser update the history file?',
     'workingdir': 'Original working directory',
 }
 NOTHING_CHANGED_YET = '- Nothing changed yet.'

--- a/zest/releaser/bumpversion.py
+++ b/zest/releaser/bumpversion.py
@@ -47,6 +47,7 @@ class BumpVersion(baserelease.Basereleaser):
             feature=feature,
             history_header=HISTORY_HEADER,
             release=release,
+            update_history=True,
         ))
 
     def prepare(self):
@@ -63,9 +64,11 @@ class BumpVersion(baserelease.Basereleaser):
 
     def execute(self):
         """Make the changes and offer a commit"""
-        self._change_header()
+        if self.data['update_history']:
+            self._change_header()
         self._write_version()
-        self._write_history()
+        if self.data['update_history']:
+            self._write_history()
         self._diff_and_commit()
 
     def _grab_version(self, initial=False):

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -22,7 +22,6 @@ DATA.update({
     'dev_version_template': 'Template for development version number',
     'development_marker': 'String to be appended to version after postrelease',
     'new_version': 'New version, without development marker (so 1.1)',
-    'update_history': 'Should zest.releaser update the history file?',
 })
 
 

--- a/zest/releaser/prerelease.py
+++ b/zest/releaser/prerelease.py
@@ -19,7 +19,6 @@ PRERELEASE_COMMIT_MSG = 'Preparing release %(new_version)s'
 DATA = baserelease.DATA.copy()
 DATA.update({
     'today': 'Date string used in history header',
-    'update_history': 'Should zest.releaser update the history file?',
 })
 
 


### PR DESCRIPTION
Fixes issue #310.
See also https://github.com/collective/zestreleaser.towncrier/pull/11