### PR TITLE
Refuse to edit history header when it may be from already released version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog for zest.releaser
 6.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Refuse to edit history header when it may be from an already released version.
+  We look for "unreleased" in it.  Give a warning when this happens.
+  Fixes `issue 311 <https://github.com/zestsoftware/zest.releaser/issues/311>`_.
+  [maurits]
 
 
 6.16.0 (2019-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog for zest.releaser
 6.16.1 (unreleased)
 -------------------
 
-- Refuse to edit history header when it may be from an already released version.
-  We look for "unreleased" in it.  Give a warning when this happens.
+- Refuse to edit history header when it looks to be from an already released version.
+  We look for a date in it (like 2019-02-20).  Give a warning when this happens.
   Fixes `issue 311 <https://github.com/zestsoftware/zest.releaser/issues/311>`_.
   [maurits]
 

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -184,8 +184,8 @@ class Basereleaser(object):
         if not add and self.data.get('has_released_header'):
             # So we are editing a line, but it already has a release date.
             logger.warning(
-                'Refused to edit history header, because it looks to be from '
-                'an already released version with a date. '
+                'Refused to edit the first history heading, because it looks '
+                'to be from an already released version with a date. '
                 'Would have wanted to set this header: %s',
                 good_heading
             )

--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -231,6 +231,6 @@ The old one is left untouched:
     - Nothing changed yet.
     <BLANKLINE>
     <BLANKLINE>
-    1.3 (2009-11-26)
+    1.0 (1972-12-25)
     <BLANKLINE>
     - hello


### PR DESCRIPTION
We look for "unreleased" in it.  Give a warning when this happens.
Fixes issue #311.

This is a more general fix than the one in PR #313 which is specific for `bumpversion`. But it seems good to do both.

The current one might possibly have negative side effects when people do not have 'unreleased' in their changelog, but say `(release date to be determined)`. So it could be that this fixes some things and breaks something else. To counter this, we might just need support for an extra item in `setup.cfg`, `unreleased-marker` similar to the `development-marker` that we already have.

But it already fixes something in the tests: in `postrelease.txt` we call `prerelease` and until now this would change `1.0 (1972-12-25)` into `1.3 (<today>)`. With the current PR, it keeps the header, and it would log a warning, though that is not visible in the tests.