### PR TITLE
Do not go to the root of the repo by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog for zest.releaser
 6.18.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Do not go to the root of the repo by default.
+  When you were not in the root of a repo, ``zest.releaser`` already asked if you wanted to go there.
+  The default answer has now changed from yes to no.
+  Issue `#326 <https://github.com/zestsoftware/zest.releaser/issues/326>`_.  [maurits]
 
 
 6.18.2 (2019-04-10)

--- a/zest/releaser/choose.py
+++ b/zest/releaser/choose.py
@@ -31,19 +31,19 @@ def version_control():
         curdir_contents = os.listdir(path)
         if '.svn' in curdir_contents:
             # Maybe chdir to the found root.
-            if level != 0 and utils.ask(q, default=True):
+            if level != 0 and utils.ask(q, default=False):
                 os.chdir(path)
             return svn.Subversion(path)
         elif '.hg' in curdir_contents:
-            if level != 0 and utils.ask(q, default=True):
+            if level != 0 and utils.ask(q, default=False):
                 os.chdir(path)
             return hg.Hg(path)
         elif '.bzr' in curdir_contents:
-            if level != 0 and utils.ask(q, default=True):
+            if level != 0 and utils.ask(q, default=False):
                 os.chdir(path)
             return bzr.Bzr(path)
         elif '.git' in curdir_contents:
-            if level != 0 and utils.ask(q, default=True):
+            if level != 0 and utils.ask(q, default=False):
                 os.chdir(path)
             return git.Git(path)
         # Get parent.

--- a/zest/releaser/tests/choose.txt
+++ b/zest/releaser/tests/choose.txt
@@ -44,12 +44,12 @@ It works when we are in a sub directory too:
     >>> os.chdir('src')
     >>> utils.test_answer_book.set_answers(['n'])
     >>> choose.version_control()
-    Question: You are NOT in the root of the repository. Do you want to go there? (Y/n)?
+    Question: You are NOT in the root of the repository. Do you want to go there? (y/N)?
     Our reply: n
     <Git at TESTTEMP/tha.example-git src>
     >>> utils.test_answer_book.set_answers(['y'])
     >>> choose.version_control()
-    Question: You are NOT in the root of the repository. Do you want to go there? (Y/n)?
+    Question: You are NOT in the root of the repository. Do you want to go there? (y/N)?
     Our reply: y
     <Git at TESTTEMP/tha.example-git .>
 


### PR DESCRIPTION
When you were not in the root of a repo, `zest.releaser` already asked if you wanted to go there.
The default answer has now changed from yes to no.
See issue #326.