### PR TITLE
Pin more versions on Python 2.7 (and PyPy).

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -22,7 +22,7 @@ Babel = 2.5.3
 CommonMark = 0.7.5
 Jinja2 = 2.10
 MarkupSafe = 1.1.1
-Pygments = 2.5.2
+Pygments = 2.6.1
 SecretStorage = 3.1.1
 Sphinx = 1.7.1
 alabaster = 0.7.10
@@ -31,6 +31,7 @@ certifi = 2018.1.18
 cffi = 1.13.2
 collective.recipe.sphinxbuilder = 1.0
 colorama = 0.3.9
+contextlib2 = 0.6.0.post1
 cryptography = 2.8
 docutils = 0.14
 future = 0.16.0
@@ -43,16 +44,20 @@ keyring = 21.0.0
 martian = 1.1
 more-itertools = 8.0.2
 packaging = 17.1
+pathlib2 = 2.3.5
+pep517 = 0.8.2
 pkginfo = 1.4.2
 pycparser = 2.19
 pyparsing = 2.2.0
 pytz = 2018.3
 requests = 2.22.0
 requests-toolbelt = 0.8.0
+scandir = 1.10.0
 six = 1.11.0
 snowballstemmer = 1.2.1
 sphinx-rtd-theme = 0.2.4
 sphinxcontrib-websupport = 1.0.1
+toml = 0.10.1
 tqdm = 4.19.6
 typing = 3.6.4
 urllib3 = 1.22
@@ -68,10 +73,13 @@ zope.testing = 4.6.2
 zope.testrunner = 4.8.1
 
 [versions:python27]
-twine = <= 2
+twine = < 2
+check-manifest = 0.41
+Pygments = < 2.6
+configparser = < 5
 
 [versions:python35]
-twine = <= 2
+twine = < 2
 
 [script]
 recipe = zc.recipe.egg


### PR DESCRIPTION
I hope this fixes Travis.
We get too new versions of packages, that are not compatible.

Works locally for Python 2.7 and PyPy.

(`git svn` tests are failing because I don't have this properly installed anymore it seems. And only on PyPy a few mercurial tests fail because of a missing user name, which is not the case on 2.7. But this is both likely only a local problem.)