### PR TITLE
Fix TypeError on Python 2.7 and git-lfs issue

### DIFF
--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -57,7 +57,7 @@ NOTHING_CHANGED_YET = '- Nothing changed yet.'
 class Basereleaser(object):
 
     def __init__(self, vcs=None):
-        os.environ["ZESTRELEASER"] = "We are called from within zest.releaser"
+        os.environ[str("ZESTRELEASER")] = str("We are called from within zest.releaser")
         # ^^^ Env variable so called tools can detect us. Don't depend on the
         # actual text, just on the variable's name.
         if vcs is None:

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -764,8 +764,6 @@ def _subprocess_open(p, command, input_value, show_stderr):
         if stderr_output:
             logger.debug("Stderr of running command '%s':\n%s",
                          format_command(command), stderr_output)
-    o.close()
-    e.close()
     return result
 
 

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -741,11 +741,10 @@ __command_is_string__ = False
 
 
 def _subprocess_open(p, command, input_value, show_stderr):
-    i, o, e = (p.stdin, p.stdout, p.stderr)
     if input_value:
-        i.write(input_value.encode(INPUT_ENCODING))
-    i.close()
-    (stdout_output, stderr_output) = p.communicate()
+        (stdout_output, stderr_output) = p.communicate(input_value.encode(INPUT_ENCODING))
+    else:
+        (stdout_output, stderr_output) = p.communicate()
     # We assume that the output from commands we're running is text.
     if not isinstance(stdout_output, six.text_type):
         stdout_output = stdout_output.decode(OUTPUT_ENCODING)

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -745,8 +745,7 @@ def _subprocess_open(p, command, input_value, show_stderr):
     if input_value:
         i.write(input_value.encode(INPUT_ENCODING))
     i.close()
-    stdout_output = o.read()
-    stderr_output = e.read()
+    (stdout_output, stderr_output) = p.communicate()
     # We assume that the output from commands we're running is text.
     if not isinstance(stdout_output, six.text_type):
         stdout_output = stdout_output.decode(OUTPUT_ENCODING)


### PR DESCRIPTION
I bumped into a couple of issues using the latest version of zest.releaser under python 2.7, while trying to release code that uses git and git-lfs.

This PR address both these issues.