### PR TITLE
Removed Python 2 fallbacks.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,18 +90,14 @@ of ``zest.releaser`` users:
   packaging.  Mostly it performs checks on the ``setup.py`` file, like
   checking for Python version classifiers.
 
-- chardet_, the universal character encoding detector. To do the right thing
-  in case your readme or changelog is in a non-utf-8 character set.
-
-- readme_ to check your long description in the same way as pypi does. No more
+- readme_renderer_ to check your long description in the same way as pypi does. No more
   unformatted restructured text on your pypi page just because there was a
   small error somewhere. Handy.
 
 .. _wheel: https://pypi.org/project/wheel
 .. _`check-manifest`: https://pypi.org/project/check-manifest
 .. _pyroma: https://pypi.org/project/pyroma
-.. _chardet: https://pypi.org/project/chardet
-.. _readme: https://pypi.org/project/readme
+.. _readme_renderer: https://pypi.org/project/readme_renderer
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
     ],
     extras_require={
         "recommended": [
-            "chardet",
             "check-manifest",
             "pyroma",
             "readme_renderer",

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -385,15 +385,7 @@ class Basereleaser:
 
         diff_cmd = self.vcs.cmd_diff()
         diff = execute_command(diff_cmd)
-        if sys.version.startswith("2.6.2"):
-            # python2.6.2 bug... http://bugs.python.org/issue5170 This is the
-            # spot it can surface as we show a part of the changelog which can
-            # contain every kind of character.  The rest is mostly ascii.
-            print("Diff results:")
-            print(diff)
-        else:
-            # Common case
-            logger.info("The '%s':\n\n%s\n", utils.format_command(diff_cmd), diff)
+        logger.info("The '%s':\n\n%s\n", utils.format_command(diff_cmd), diff)
         if utils.ask("OK to commit this"):
             msg = commit_msg % self.data
             msg = self.update_commit_message(msg)

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -44,9 +44,6 @@ class BaseConfig:
 
     def _get_text(self, section, key, default=None, raw=False):
         """Get a text from the config.
-
-        We want unicode, also on Python 2.
-        In Python 3 this is already the case.
         """
         result = default
         if self.config is not None:
@@ -54,8 +51,6 @@ class BaseConfig:
                 result = self.config.get(section, key, raw=raw)
             except (NoSectionError, NoOptionError, ValueError):
                 return result
-            if not isinstance(result, str):
-                result = result.decode("utf-8")
         return result
 
 

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -740,13 +740,11 @@ Do real strings or tuples:
     >>> print(utils.format_command(('x', 'y', 'zet')))
     x y zet
 
-Show some real action.
-This should not contain a literal u'...' in the output on Python 2.7,
-but that is hard to test, as we normalize the output to not show it:
+Show some real action, and let's include non-ascii:
 
-    >>> cmd = ['git', 'tag', '1.0', '-m', u'Possibly unicode']
+    >>> cmd = ['git', 'tag', '1.0', '-m', '\xae registered trademark']
     >>> print(utils.format_command(cmd))
-    git tag 1.0 -m 'Possibly unicode'
+    git tag 1.0 -m '® registered trademark'
 
 
 Reading text files
@@ -755,15 +753,16 @@ Reading text files
 When reading text files, reliable encoding handling is a pain. Did anyone say
 "corner cases"?
 
-There once was a bug with python 3. ``b'example'[0] gives back an integer
-instead of an ``b'e'``. We had to compensate for that so that the following
-example works:
+On python 3 you have to watch out with bytes.
+b'example'[0] gives back an integer 101 instead of b'e'.
+101 is the number of 'e' in the ascii table.
+We needed to compensate for that so that the following example works:
 
     >>> import os
     >>> import tempfile
     >>> _, example_filename = tempfile.mkstemp()
     >>> with open(example_filename, 'wb') as f:
-    ...     _ = f.write(u'# -*- coding: utf-8 -*-\nblaá'.encode('utf-8'))
+    ...     _ = f.write('# -*- coding: utf-8 -*-\nblaá'.encode('utf-8'))
     >>> lines, encoding = utils.read_text_file(example_filename)
     >>> 'bla' in lines[1]
     True


### PR DESCRIPTION
The main ones:

- Always use tokenize.open instead of chardet to detect the encoding.
  We meant chardet for Python 2, although theoretically it might
  be needed in corner cases on Python 3.  Let's try without it.
- Use shlex.quote instead of our simpler quoting in format_command.