### PR TITLE
Use subprocess.run for executing commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,5 +16,7 @@ Big cleanup to ease future development:
 
 - Switched from Travis to GitHub Actions.
 
+- Simplified running commands by using ``subprocess.run``.
+
 
 .. # Note: for older changes see ``doc/sources/changelog.rst``.

--- a/zest/releaser/tests/cmd_error.py
+++ b/zest/releaser/tests/cmd_error.py
@@ -1,0 +1,4 @@
+# Python script to test some corner cases that print warnings to stderr.
+import sys
+
+print(sys.argv[1], file=sys.stderr)

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -463,28 +463,27 @@ We want to discover errors and show them in red.
     True
 
 Warnings may also end up in the error output.  That may be unwanted.
-Note: Setting ``__command_is_string__`` is a special hack implemented
-only for this test-case.  It makes ``utils._execute_command()`` to
-accept a command-string and execute it via a shell.
+We have a script to test this, which passes all input to std error.
+
+    >>> import os
+    >>> import zest.releaser.tests
+    >>> test_dir = os.path.dirname(zest.releaser.tests.__file__)
+    >>> script = os.path.join(test_dir, "cmd_error.py")
 
     >>> warning = "warning: no previously-included files matching '*.pyc' found anywhere in distribution."
-    >>> utils.__command_is_string__ = True
-    >>> result = utils.execute_command('echo %s > /dev/stderr' % warning)
-    >>> utils.__command_is_string__ = False
+    >>> result = utils.execute_command(['python', script, warning])
     >>> result.startswith(Fore.RED)
     False
     >>> result.startswith(Fore.MAGENTA)
     True
     >>> print(result)
-    MAGENTA warning: no previously-included files matching *.pyc found anywhere in distribution.
+    MAGENTA warning: no previously-included files matching '*.pyc' found anywhere in distribution.
 
 One similar harmless warning by distutils does not get the 'warning:'
 prefixed, so we handle it explicitly:
 
     >>> warning = "no previously-included directories found matching devsrc"
-    >>> utils.__command_is_string__ = True
-    >>> result = utils.execute_command('echo %s > /dev/stderr' % warning)
-    >>> utils.__command_is_string__ = False
+    >>> result = utils.execute_command(['python', script, warning])
     >>> result.startswith(Fore.RED)
     False
     >>> result.startswith(Fore.MAGENTA)
@@ -492,15 +491,13 @@ prefixed, so we handle it explicitly:
     >>> print(result)
     MAGENTA no previously-included directories found matching devsrc
 
-Let's do a combination:
+Let's do a combination of a warning and an actual error:
 
     >>> message = """
     ... Warn: What is the answer to life, the universe and everything?
     ...
     ... 41"""
-    >>> utils.__command_is_string__ = True
-    >>> result = utils.execute_command('echo "%s" > /dev/stderr' % message)
-    >>> utils.__command_is_string__ = False
+    >>> result = utils.execute_command(['python', script, message])
     >>> result
     '\x1b[35mWarn: What is the answer to life, the universe and everything?\n\n\x1b[31m41'
     >>> print(result)

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -18,9 +18,6 @@ import tokenize
 logger = logging.getLogger(__name__)
 
 WRONG_IN_VERSION = ["svn", "dev", "("]
-# For zc.buildout's system() method:
-MUST_CLOSE_FDS = not sys.platform.startswith("win")
-
 AUTO_RESPONSE = False
 VERBOSE = False
 INPUT_ENCODING = "UTF-8"
@@ -677,7 +674,7 @@ def _subprocess_open(p, command, show_stderr):
 
 
 def _execute_command(command):
-    """commands.getoutput() replacement that also works on windows"""
+    """Execute a command, returning stdout, plus maybe parts of stderr."""
     # Enforce the command to be a list or arguments.
     assert isinstance(command, (list, tuple))
     logger.debug("Running command: '%s'", format_command(command))
@@ -696,7 +693,6 @@ def _execute_command(command):
         "stdin": subprocess.PIPE,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
-        "close_fds": MUST_CLOSE_FDS,
         "env": env,
     }
     with subprocess.Popen(command, **process_kwargs) as process:

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -649,14 +649,14 @@ def format_command(command):
     return " ".join(args)
 
 
-def _subprocess_open(p, command, show_stderr):
-    (stdout_output, stderr_output) = p.communicate()
+def _subprocess_open(process, show_stderr):
+    (stdout_output, stderr_output) = process.stdout, process.stderr
     # We assume that the output from commands we're running is text.
     if not isinstance(stdout_output, str):
         stdout_output = stdout_output.decode(OUTPUT_ENCODING)
     if not isinstance(stderr_output, str):
         stderr_output = stderr_output.decode(OUTPUT_ENCODING)
-    if p.returncode or show_stderr or "Traceback" in stderr_output:
+    if process.returncode or show_stderr or "Traceback" in stderr_output:
         # Some error occured
         result = stdout_output + get_errors(stderr_output)
     else:
@@ -667,7 +667,7 @@ def _subprocess_open(p, command, show_stderr):
         if stderr_output:
             logger.debug(
                 "Stderr of running command '%s':\n%s",
-                format_command(command),
+                format_command(process.args),
                 stderr_output,
             )
     return result
@@ -695,8 +695,8 @@ def _execute_command(command):
         "stderr": subprocess.PIPE,
         "env": env,
     }
-    with subprocess.Popen(command, **process_kwargs) as process:
-        return _subprocess_open(process, command, show_stderr)
+    process = subprocess.run(command, **process_kwargs)
+    return _subprocess_open(process, show_stderr)
 
 
 def get_errors(stderr_output):

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -652,13 +652,6 @@ def format_command(command):
     return " ".join(args)
 
 
-# USE WITH CAUTION: If True, allow the command to be a string instead
-# of a list of arguments. The command-string will be executed via a
-# shell. This should only be used in the test-suite for testing
-# redirects.
-__command_is_string__ = False
-
-
 def _subprocess_open(p, command, show_stderr):
     (stdout_output, stderr_output) = p.communicate()
     # We assume that the output from commands we're running is text.
@@ -666,9 +659,6 @@ def _subprocess_open(p, command, show_stderr):
         stdout_output = stdout_output.decode(OUTPUT_ENCODING)
     if not isinstance(stderr_output, str):
         stderr_output = stderr_output.decode(OUTPUT_ENCODING)
-    # TODO.  Note that the returncode is always None, also after
-    # running p.kill().  The shell=True may be tripping us up.  For
-    # some ideas, see http://stackoverflow.com/questions/4789837
     if p.returncode or show_stderr or "Traceback" in stderr_output:
         # Some error occured
         result = stdout_output + get_errors(stderr_output)
@@ -688,10 +678,8 @@ def _subprocess_open(p, command, show_stderr):
 
 def _execute_command(command):
     """commands.getoutput() replacement that also works on windows"""
-    # Enforce the command to be a list or arguments, except if
-    # ``__command_is_string__`` is string is set, which is meant to be
-    # used by the test-suite only (see above).
-    assert isinstance(command, (list, tuple)) or __command_is_string__
+    # Enforce the command to be a list or arguments.
+    assert isinstance(command, (list, tuple))
     logger.debug("Running command: '%s'", format_command(command))
     if command[0].startswith(sys.executable):
         env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
@@ -705,7 +693,6 @@ def _execute_command(command):
         env = None
         show_stderr = True
     process_kwargs = {
-        "shell": not isinstance(command, (list, tuple)),
         "stdin": subprocess.PIPE,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -659,13 +659,8 @@ def format_command(command):
 __command_is_string__ = False
 
 
-def _subprocess_open(p, command, input_value, show_stderr):
-    if input_value:
-        (stdout_output, stderr_output) = p.communicate(
-            input_value.encode(INPUT_ENCODING)
-        )
-    else:
-        (stdout_output, stderr_output) = p.communicate()
+def _subprocess_open(p, command, show_stderr):
+    (stdout_output, stderr_output) = p.communicate()
     # We assume that the output from commands we're running is text.
     if not isinstance(stdout_output, str):
         stdout_output = stdout_output.decode(OUTPUT_ENCODING)
@@ -691,7 +686,7 @@ def _subprocess_open(p, command, input_value, show_stderr):
     return result
 
 
-def _execute_command(command, input_value=""):
+def _execute_command(command):
     """commands.getoutput() replacement that also works on windows"""
     # Enforce the command to be a list or arguments, except if
     # ``__command_is_string__`` is string is set, which is meant to be
@@ -718,7 +713,7 @@ def _execute_command(command, input_value=""):
         "env": env,
     }
     with subprocess.Popen(command, **process_kwargs) as process:
-        return _subprocess_open(process, command, input_value, show_stderr)
+        return _subprocess_open(process, command, show_stderr)
 
 
 def get_errors(stderr_output):
@@ -768,7 +763,7 @@ def execute_command(command, allow_retry=False, fail_message=""):
     - Retry
     - Continue
 
-    There is an error is there is a red color in the output.
+    There is an error when there is a red color in the output.
 
     It might be a warning, but we cannot detect the distinction.
     """

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -20,9 +20,6 @@ logger = logging.getLogger(__name__)
 WRONG_IN_VERSION = ["svn", "dev", "("]
 AUTO_RESPONSE = False
 VERBOSE = False
-INPUT_ENCODING = "UTF-8"
-if getattr(sys.stdin, "encoding", None):
-    INPUT_ENCODING = sys.stdin.encoding
 
 
 def fs_to_text(fs_name):
@@ -287,8 +284,6 @@ def get_input(question):
     if not TESTMODE:
         # Normal operation.
         result = input(question)
-        if not isinstance(result, str):
-            result = result.decode(INPUT_ENCODING)
         return result.strip()
     # Testing means no interactive input. Get it from answers_for_testing.
     print("Question: %s" % question)

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -641,22 +641,6 @@ def format_command(command):
     return " ".join(args)
 
 
-def _subprocess_open(process, show_stderr):
-    if process.returncode or show_stderr or "Traceback" in process.stderr:
-        # Some error occured
-        return process.stdout + get_errors(process.stderr)
-    # Only return the stdout. Stderr only contains possible
-    # weird/confusing warnings that might trip up extraction of version
-    # numbers and so.
-    if process.stderr:
-        logger.debug(
-            "Stderr of running command '%s':\n%s",
-            format_command(process.args),
-            process.stderr,
-        )
-    return process.stdout
-
-
 def _execute_command(command):
     """Execute a command, returning stdout, plus maybe parts of stderr."""
     # Enforce the command to be a list or arguments.
@@ -685,7 +669,19 @@ def _execute_command(command):
         "universal_newlines": True,
     }
     process = subprocess.run(command, **process_kwargs)
-    return _subprocess_open(process, show_stderr)
+    if process.returncode or show_stderr or "Traceback" in process.stderr:
+        # Some error occured
+        return process.stdout + get_errors(process.stderr)
+    # Only return the stdout. Stderr only contains possible
+    # weird/confusing warnings that might trip up extraction of version
+    # numbers and so.
+    if process.stderr:
+        logger.debug(
+            "Stderr of running command '%s':\n%s",
+            format_command(process.args),
+            process.stderr,
+        )
+    return process.stdout
 
 
 def get_errors(stderr_output):


### PR DESCRIPTION
If I recall correctly, our `_execute_command` function started out as a copy of some code from `zc.buildout`, with as comment that it was a "commands.getoutput() replacement that also works on windows".
Meanwhile, the entire [`commands` module was removed in Py 3](https://docs.python.org/2.7/library/commands.html?highlight=commands#module-commands)  and you should use `subprocess` now.

We already did this, but we were using `subprocess.Popen`. The [`subprocess` documentation says](https://docs.python.org/3.10/library/subprocess.html):

> The recommended approach to invoking subprocesses is to use the run() function for all use cases it can handle. For more advanced use cases, the underlying Popen interface can be used directly.
> The run() function was added in Python 3.5

It looks like our use cases can be handled just fine by `run`, so I did that.
And I got rid of some more encoding-related and Windows-specific code, with the idea that standard Python probably knows better how to handle this than we do.

The amount of code changed in this PR is not so much, but it covers some complicated code that I don't usually touch. It may help to look at the smaller individual commits that simplify the code step by step.