### PR TITLE
Add --headless option for longtest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for zest.releaser
 7.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add ``--headless`` option to ``longtest``.
 
 
 7.0.0a1 (2021-12-01)

--- a/zest/releaser/longtest.py
+++ b/zest/releaser/longtest.py
@@ -32,14 +32,14 @@ HTML_POSTFIX = """
 logger = logging.getLogger(__name__)
 
 
-def show_longdesc():
+def show_longdesc(headless):
     if not HAVE_README:
         logging.error(
             "To check the long description, we need the 'readme_renderer' "
             "package. "
             "(It is included if you install `zest.releaser[recommended]`)"
         )
-        sys.exit(1)
+        return 1
 
     filename = tempfile.mktemp(".html")
     # Note: for the setup.py call we use _execute_command() from our
@@ -55,7 +55,10 @@ def show_longdesc():
         warning_text = warnings.getvalue()
         warning_text = warning_text.replace("<string>", rst_filename)
         print(warning_text)
-        sys.exit(1)
+        return 1
+
+    if headless:
+        return 0
 
     if "<html" not in html[:20]:
         # Add a html declaration including utf-8 indicator
@@ -67,8 +70,18 @@ def show_longdesc():
     url = "file://" + filename
     logging.info("Opening %s in your webbrowser.", url)
     webbrowser.open(url)
+    return 0
 
 
 def main():
+    parser = utils.base_option_parser()
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        dest="feature",
+        default=False,
+        help="Do not open a browser window with the HTML result")
+    options = utils.parse_options(parser)
     utils.configure_logging()
-    show_longdesc()
+    code = show_longdesc(headless=options.headless)
+    sys.exit(code)

--- a/zest/releaser/longtest.py
+++ b/zest/releaser/longtest.py
@@ -78,7 +78,7 @@ def main():
     parser.add_argument(
         "--headless",
         action="store_true",
-        dest="feature",
+        dest="headless",
         default=False,
         help="Do not open a browser window with the HTML result")
     options = utils.parse_options(parser)


### PR DESCRIPTION
In order to avoid discovering description format issues when uploading to Pypi, I would like to use `longtest` in a CI job.

One idea was to pass a flag that would skip the browser step. What do you think?