### PR TITLE
In prerelease, check with pep440 if the version is canonical.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog for zest.releaser
 7.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Bug 381: In ``prerelease``, check with ``pep440`` if the version is canonical.
+  Added ``pep440`` to the ``recommended`` extra, not to the core dependencies:
+  ``zest.releaser`` can also be used for non-Python projects.
+  [maurits]
 
 
 7.0.0a2 (2022-02-10)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     extras_require={
         "recommended": [
             "check-manifest",
+            "pep440",
             "pyroma",
             "readme_renderer",
             "wheel",


### PR DESCRIPTION
Fixes https://github.com/zestsoftware/zest.releaser/issues/381

I added `pep440` to the `recommended` extra, not to the core dependencies: `zest.releaser` can also be used for non-Python projects.

Sample `prerelease` run with bad versions:

```
Enter version [7.0.0a3]: bad-version-1
WARNING: 'bad-version-1' is not a canonical Python package version.
Do you want to use this version anyway? (Y/n)? n
Enter version [7.0.0a3]: even worse version 2
WARNING: 'even worse version 2' is not a canonical Python package version.
Do you want to use this version anyway? (Y/n)? y
INFO: Set setup.py's version to 'even worse version 2'
INFO: Changed version from 7.0.0a3.dev0 to even worse version 2
```

I tried adding tests, but could not get it to work.