### PR TITLE
🐛 Add option to add message before the commit messages for zest.releaser 6.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,13 @@ Changelog for zest.releaser
 6.22.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Bug 388: Optionally add prefix text to commit messages.  This can be used to
+  avoid running Travis Continuous Integration builds.  See
+  http://docs.travis-ci.com/user/how-to-skip-a-build/.  To activate
+  this, add ``prefix-message = [ci skip]`` to a ``[zest.releaser]``
+  section in the ``setup.cfg`` of your package, or your global
+  ``~/.pypirc``.  Or add your favorite geeky quotes there.
+  [LvffY]
 
 6.22.2 (2021-10-29)
 -------------------

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -93,6 +93,9 @@ create-wheel = yes / no
 extra-message = [ci skip]
     Extra message to add to each commit (prerelease, postrelease).
 
+prefix-message = [ci skip]
+    Prefix message to add at the beginning of each commit (prerelease, postrelease).
+
 no-input = yes / no
     Default: no.  Set this to yes to accept default answers for all
     questions.

--- a/doc/source/uploading.rst
+++ b/doc/source/uploading.rst
@@ -164,7 +164,8 @@ configuration in your ``setup.cfg`` or global ``~/.pypirc``.  One use
 case for this is telling Travis to skip Continuous Integration builds::
 
   [zest.releaser]
-  extra-message = [ci skip]
+  extra-message = This will be added after the message
+  prefix-message = This will be added before the message
 
 
 Signing your commits or tags with git

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -430,7 +430,10 @@ class Basereleaser(object):
         raise NotImplementedError()
 
     def update_commit_message(self, msg):
+        prefix_message = self.pypiconfig.prefix_message()
         extra_message = self.pypiconfig.extra_message()
+        if prefix_message:
+            msg = "%s %s" % (prefix_message, msg)
         if extra_message:
             msg += '\n\n%s' % extra_message
         return msg

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -282,6 +282,24 @@ class PypiConfig(BaseConfig):
         """
         return self._get_boolean('zest.releaser', 'release', default=True)
 
+    def __get_message_config__(self, config_name):
+        """
+        Return the value of the message configuration based on its name.
+
+        If the configuration does not exist or can't be retrieved, return an empty string.
+
+        :param config_name: Name of the configuration to obtain from configuration file
+        :return: The configuration value or an empty string
+        """
+        default = ''
+        if self.config is None:
+            return default
+        try:
+            result = self._get_text('zest.releaser', config_name, default=default)
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
+
     def extra_message(self):
         """Return extra text to be added to commit messages.
 
@@ -295,15 +313,22 @@ class PypiConfig(BaseConfig):
             [zest.releaser]
             extra-message = [ci skip]
         """
-        default = ''
-        if self.config is None:
-            return default
-        try:
-            result = self._get_text(
-                'zest.releaser', 'extra-message', default=default)
-        except (NoSectionError, NoOptionError, ValueError):
-            return default
-        return result
+        return self.__get_message_config__('extra-message')
+
+    def prefix_message(self):
+        """Return extra text to be added before the commit message.
+
+        This can for example be used to skip CI builds.  This at least
+        works for Travis.  See
+        http://docs.travis-ci.com/user/how-to-skip-a-build/
+
+        Enable this mode by adding a ``prefix-message`` option, either in the
+        package you want to release, or in your ~/.pypirc::
+
+            [zest.releaser]
+            prefix-message = [ci skip]
+        """
+        return self.__get_message_config__('prefix-message')
 
     def history_file(self):
         """Return path of history file.

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -37,7 +37,7 @@ Two methods are unimplemented:
     ...
     NotImplementedError
 
-We can update commit messages based on what we find in ``setup.cfg``::
+We can suffix commit messages based on what we find in ``setup.cfg``::
 
     >>> lines = [
     ...     "[zest.releaser]",
@@ -76,3 +76,54 @@ And check with multiple lines.
     <BLANKLINE>
     Where is my towel?
     Not again.
+
+We can prefix commit messages based on what we find in ``setup.cfg``::
+
+    >>> lines = [
+    ...     "[zest.releaser]",
+    ...     "prefix-message = Aargh!"]
+    >>> with open('setup.cfg', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+    >>> base = baserelease.Basereleaser()
+    >>> print(base.update_commit_message('Ni!'))
+    Aargh! Ni!
+
+
+Check that this works with non-ascii too.
+
+    >>> lines = [
+    ...     "[zest.releaser]".encode('utf-8'),
+    ...     "prefix-message = \u2603".encode('utf-8')]
+    >>> with open('setup.cfg', 'wb') as f:
+    ...     _ = f.write(b'\n'.join(lines))
+    >>> base = baserelease.Basereleaser()
+    >>> base.update_commit_message('Ni!')
+    '\u2603 Ni!'
+
+And check with multiple lines.
+
+    >>> lines = [
+    ...     "[zest.releaser]",
+    ...     "prefix-message =",
+    ...     "    Where is my towel?",
+    ...     "    Not again."]
+    >>> with open('setup.cfg', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+    >>> base = baserelease.Basereleaser()
+    >>> print(base.update_commit_message('Ni!'))
+    Where is my towel?
+    Not again. Ni!
+
+We can prefix and suffix commit messages based on what we find in ``setup.cfg``::
+
+    >>> lines = [
+    ...     "[zest.releaser]",
+    ...     "extra-message = after",
+    ...     "prefix-message = before"]
+    >>> with open('setup.cfg', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+    >>> base = baserelease.Basereleaser()
+    >>> print(base.update_commit_message('Ni!'))
+    before Ni!
+    <BLANKLINE>
+    after

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -39,6 +39,7 @@ There are two styles of ``.pypirc`` files.  The old one just for pypi:
     <BLANKLINE>
     [zest.releaser]
     extra-message = [ci skip]
+    prefix-message = before
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_old)
     >>> pypiconfig.distutils_servers()
     ['pypi']
@@ -71,6 +72,7 @@ And the new format that allows multiple uploads:
     <BLANKLINE>
     [zest.releaser]
     extra-message = [ci skip]
+    prefix-message = before
     >>> pypiconfig = pypi.PypiConfig(config_filename=pypirc_new)
     >>> from pprint import pprint
     >>> pprint(sorted(pypiconfig.distutils_servers()))


### PR DESCRIPTION
Closes #388  