### PR TITLE
Fix postrelease tests.

### DIFF
--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -123,7 +123,8 @@ but 0.2.20:
     Our reply: n
 
 Releases without numbers at the end should not fluster us even when we
-cannot suggest a reasonable number. We'll ask for a version until we get one:
+cannot suggest a reasonable number. We'll ask for a version until we get one.
+This this case it is not a canonical version so we have an extra question about this:
 
     >>> add_changelog_entry()
     >>> utils.test_answer_book.set_answers(['', '', '0.3beta', ''])
@@ -131,6 +132,8 @@ cannot suggest a reasonable number. We'll ask for a version until we get one:
     Question...
     Question: Enter version [0.2.20]:
     Our reply: 0.3beta
+    Question: Do you want to use this version anyway? (Y/n)?
+    Our reply: <ENTER>
     Checking data dict
     Question: OK to commit this (Y/n)?
     Our reply: <ENTER>


### PR DESCRIPTION
An extra question is asked because we try to set a non-canonical version. Sample failure:

```
File "/Users/maurits/community/zest.releaser/zest/releaser/tests/postrelease.txt", line 130, in postrelease.txt
Failed example:
    prerelease.main()
Differences (ndiff with -expected +actual):
    - Question...
    + Question: Run pyroma on the package before tagging? (Y/n)? 
    + Our reply: <ENTER>
    + Question: Do you want to run check-manifest? (Y/n)? 
    + Our reply: <ENTER>
    + lists of files in version control and sdist match
    + Changelog entries for version 0.2.20:
    + <BLANKLINE>
    + 0.2.20 (unreleased)
    + -------------------
    + <BLANKLINE>
    + - Brown bag release.
    + <BLANKLINE>
    + <BLANKLINE>
    + 0.2.19 (1972-12-25)
    + -------------------
    - Question: Enter version [0.2.20]:
    + Question: Enter version [0.2.20]: 
    ?                                  +
      Our reply: 0.3beta
    + Question: Do you want to use this version anyway? (Y/n)? 
    + Our reply: <ENTER>
      Checking data dict
    - Question: OK to commit this (Y/n)?
    + Question: OK to commit this (Y/n)? 
    ?                                   +
      Our reply: <ENTER>
```