### PR TITLE
Add support for Python 3.11, remove z3c.testsetup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",   "py310"]
+        - ["3.11",   "py311"]
         - ["pypy3", "pypy3"]
 
     runs-on: ubuntu-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for zest.releaser
 7.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Python 3.11, remove ``z3c.testsetup`` from test dependencies.  [maurits]
 
 
 7.0.0 (2022-09-09)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
             "wheel",
         ],
         "test": [
-            "z3c.testsetup >= 0.8.4",
             "zope.testing",
             "zope.testrunner",
             "wheel",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36,py37,py38,py39,py310,pypy3
+    py36,py37,py38,py39,py310,py311,pypy3
 
 [testenv]
 usedevelop = true

--- a/zest/releaser/tests/addchangelogentry.txt
+++ b/zest/releaser/tests/addchangelogentry.txt
@@ -1,10 +1,6 @@
 Detailed tests of addchangelogentry.py
 ======================================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Several items are prepared for us.
 
 A git checkout of a project:

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -1,10 +1,6 @@
 Detailed tests of baserelease.py
 ================================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Change to a git dir:
 
     >>> gitsourcedir

--- a/zest/releaser/tests/bumpversion.txt
+++ b/zest/releaser/tests/bumpversion.txt
@@ -1,10 +1,6 @@
 Detailed tests of bumpversion.py
 ================================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Several items are prepared for us.
 
 A git checkout of a project:

--- a/zest/releaser/tests/choose.txt
+++ b/zest/releaser/tests/choose.txt
@@ -1,10 +1,6 @@
 Detailed tests of choose.py
 ===========================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Some initial imports:
 
     >>> from zest.releaser import choose

--- a/zest/releaser/tests/fullrelease.txt
+++ b/zest/releaser/tests/fullrelease.txt
@@ -1,10 +1,6 @@
 Fullrelease process with --no-input
 ===================================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Several items are prepared for us.
 
 A git checkout of a project:

--- a/zest/releaser/tests/functional-git.txt
+++ b/zest/releaser/tests/functional-git.txt
@@ -1,10 +1,6 @@
 Integration test
 ================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Several items are prepared for us.
 
 A git directory (repository and checkout in one):

--- a/zest/releaser/tests/functional-with-hooks.txt
+++ b/zest/releaser/tests/functional-with-hooks.txt
@@ -1,10 +1,6 @@
 Integration test
 ================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 This test is based on the functional tests using a git repository, but enables
 releaser hooks on the test package and ensures that they run.
 

--- a/zest/releaser/tests/git.txt
+++ b/zest/releaser/tests/git.txt
@@ -1,10 +1,6 @@
 Detailed tests of git.py
 ========================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Some initial imports:
 
     >>> from zest.releaser import git

--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -1,10 +1,6 @@
 Detailed tests of postrelease.py
 ================================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Several items are prepared for us.
 
 A git checkout of a project:

--- a/zest/releaser/tests/preparedocs.txt
+++ b/zest/releaser/tests/preparedocs.txt
@@ -1,8 +1,6 @@
 Documentation utility functions
 ===============================
 
-.. :doctest:
-
 We're testing ``preparedocs.py`` here:
 
     >>> from zest.releaser import preparedocs

--- a/zest/releaser/tests/prerelease.txt
+++ b/zest/releaser/tests/prerelease.txt
@@ -1,10 +1,6 @@
 Detailed tests of prerelease.py
 ===============================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Several items are prepared for us.
 
 A git checkout of a project:

--- a/zest/releaser/tests/pypi.txt
+++ b/zest/releaser/tests/pypi.txt
@@ -1,8 +1,6 @@
 Detailed tests of pypi.py
 =========================
 
-.. :doctest:
-
 Note on test setup: we don't use the "big" setup/teardown methods here.
 
     >>> from zest.releaser import pypi

--- a/zest/releaser/tests/release.txt
+++ b/zest/releaser/tests/release.txt
@@ -1,10 +1,6 @@
 Detailed tests of release.py
 ============================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Some initial imports:
 
     >>> from zest.releaser import release

--- a/zest/releaser/tests/test_setup.py
+++ b/zest/releaser/tests/test_setup.py
@@ -53,7 +53,6 @@ checker = renormalizing.RENormalizing(
     ]
 )
 
-# test_suite = z3c.testsetup.register_all_tests("zest.releaser", checker=checker)
 
 
 def test_suite():

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -1,8 +1,6 @@
 Utility functions
 =================
 
-.. :doctest:
-
 We're testing ``utils.py`` here:
 
     >>> from zest.releaser import utils

--- a/zest/releaser/tests/vcs.txt
+++ b/zest/releaser/tests/vcs.txt
@@ -1,10 +1,6 @@
 Detailed tests of vcs.py
 ========================
 
-.. :doctest:
-.. :setup: zest.releaser.tests.functional.setup
-.. :teardown: zest.releaser.tests.functional.teardown
-
 Some initial imports and utility functions:
 
     >>> from zest.releaser import vcs


### PR DESCRIPTION
`z3c.testsetup` is incompatible with Python 3.11.
Fixes https://github.com/zestsoftware/zest.releaser/issues/12 (or at least part of it).