### PR TITLE
Add --final option to bumpversion command.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog for zest.releaser
 7.0.1 (unreleased)
 ------------------
 
+- Add ``--final`` option to ``bumpversion`` command.
+  This removes alpha / beta / rc markers from the version.
+  [maurits]
+
 - Add support for Python 3.11, remove ``z3c.testsetup`` from test dependencies.  [maurits]
 
 
@@ -15,6 +19,7 @@ Changelog for zest.releaser
   section in the ``setup.cfg`` of your package, or your global
   ``~/.pypirc``.  Or add your favorite geeky quotes there.
   [LvffY]
+
 
 7.0.0a3 (2022-04-04)
 --------------------

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -1,7 +1,7 @@
 Options
 =======
 
-Zest.releaser tries not too burden you with lots of command line
+Zest.releaser tries not to burden you with lots of command line
 options.  Instead, it asks questions while doing its job.  But in some
 cases, a command line option makes sense.
 
@@ -44,11 +44,13 @@ Or on multiple lines::
 
   This was difficult."
 
-The ``bumpversion`` command accepts two mutually exclusive options:
+The ``bumpversion`` command accepts some mutually exclusive options:
 
 - With ``--feature`` we update the minor version.
 
-- With option ``--breaking`` we update the major version.
+- With ``--breaking`` we update the major version.
+
+- With ``--final`` we remove alpha / beta / rc markers from the version.
 
 
 Global options

--- a/zest/releaser/tests/bumpversion.txt
+++ b/zest/releaser/tests/bumpversion.txt
@@ -78,22 +78,45 @@ Now a feature bump::
     2.10.0 (unreleased)
     -------------------
 
-Now a breaking bump, and for this test we explicitly remove the dev marker::
+Now a breaking bump, and for this test we explicitly say to create a release candidate::
 
-    >>> utils.test_answer_book.set_answers(['3.0.0', ''])
+    >>> utils.test_answer_book.set_answers(['3.0.0rc1.dev0', ''])
     >>> sys.argv[1:] = ['--breaking']
     >>> bumpversion.main()
     Checking version bump for breaking release.
     Last tag: 2.9.4
     Current version: 2.10.0.dev0
     Question: Enter version [3.0.0.dev0]:
-    Our reply: 3.0.0
+    Our reply: 3.0.0rc1.dev0
     Checking data dict
     Question: OK to commit this (Y/n)?
     Our reply: <ENTER>
     >>> githead('setup.py')
     from setuptools import setup, find_packages
-    version = '3.0.0'
+    version = '3.0.0rc1.dev0'
+    >>> githead('CHANGES.txt')
+    Changelog of tha.example
+    ========================
+    <BLANKLINE>
+    3.0.0rc1 (unreleased)
+    ---------------------
+
+Now a final release, where we keep the dev marker::
+
+    >>> utils.test_answer_book.set_answers(['', ''])
+    >>> sys.argv[1:] = ['--final']
+    >>> bumpversion.main()
+    Checking version bump for final release.
+    Last tag: 2.9.4
+    Current version: 3.0.0rc1.dev0
+    Question: Enter version [3.0.0.dev0]:
+    Our reply: <ENTER>
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    >>> githead('setup.py')
+    from setuptools import setup, find_packages
+    version = '3.0.0.dev0'
     >>> githead('CHANGES.txt')
     Changelog of tha.example
     ========================

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -183,6 +183,22 @@ this combination a bit more:
     >>> utils.suggest_version('1.7.2.1', less_zeroes=True, levels=3)
     '1.7.2.2'
 
+You can get a suggestion for a final release:
+
+    >>> utils.suggest_version('1.2.3a1', final=True)
+    '1.2.3'
+    >>> utils.suggest_version('1.2.3b2.dev1', final=True)
+    '1.2.3.dev0'
+    >>> utils.suggest_version('1.2.3rc1', final=True)
+    '1.2.3'
+    >>> utils.suggest_version('2.0rc2', final=True)
+    '2.0'
+
+If no final release is needed, you get no suggestion:
+
+    >>> utils.suggest_version('6.0.0dev0', final=True) is None
+    True
+
 
 Asking input
 ------------


### PR DESCRIPTION
This removes alpha / beta / rc markers from the version.

Use case: Plone 6.0 has a first release candidate and the version pins contain a lot of alpha, beta, and rc releases. Before the final release, I want to make final releases of the dependencies. I know I won't remember to do this manually for all packages, so I automate it. :-)

Output from a sample run in the `Plone` package, redacted for brevity/clarity:

```
$ bumpversion --final
Checking version bump for final release.
Last tag: 6.0.0rc1
Current version: 6.0.0rc2.dev0
Enter version [6.0.0.dev0]:
INFO: Set setup.cfg's version to '6.0.0.dev0'
INFO: Changed version from 6.0.0rc2.dev0 to 6.0.0.dev0
INFO: History file CHANGES.rst updated.
INFO: The 'git diff':

diff --git a/CHANGES.rst b/CHANGES.rst

-6.0.0rc2 (unreleased)
----------------------
+6.0.0 (unreleased)
+------------------

diff --git a/setup.cfg b/setup.cfg

 [metadata]
-version = 6.0.0rc2.dev0
+version = 6.0.0.dev0
```