### PR TITLE
Add all bumpversion options to the postrelease command.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog for zest.releaser
 7.0.1 (unreleased)
 ------------------
 
+- Add the ``bumpversion`` options to the ``postrelease`` command.
+  This means ``feature``, ``breaking``, and ``--final``.
+  [rnc, maurits]
+
 - Add ``--final`` option to ``bumpversion`` command.
   This removes alpha / beta / rc markers from the version.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog for zest.releaser
 ------------------
 
 - Add the ``bumpversion`` options to the ``postrelease`` command.
-  This means ``feature``, ``breaking``, and ``--final``.
+  This means ``feature``, ``breaking``, and ``final``.
   [rnc, maurits]
 
 - Add ``--final`` option to ``bumpversion`` command.

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -44,7 +44,7 @@ Or on multiple lines::
 
   This was difficult."
 
-The ``bumpversion`` command accepts some mutually exclusive options:
+The ``bumpversion`` and ``postrelease`` commands accept some mutually exclusive options:
 
 - With ``--feature`` we update the minor version.
 

--- a/zest/releaser/postrelease.py
+++ b/zest/releaser/postrelease.py
@@ -19,11 +19,11 @@ DEV_VERSION_TEMPLATE = "%(new_version)s%(development_marker)s"
 DATA = baserelease.DATA.copy()
 DATA.update(
     {
-        'breaking': 'True if we handle a breaking (major) change',
+        "breaking": "True if we handle a breaking (major) change",
         "dev_version": "New version with development marker (so 1.1.dev0)",
         "dev_version_template": "Template for development version number",
         "development_marker": "String to be appended to version after postrelease",
-        'feature': 'True if we handle a feature (minor) change',
+        "feature": "True if we handle a feature (minor) change",
         "new_version": "New version, without development marker (so 1.1)",
     }
 )
@@ -78,8 +78,8 @@ class Postreleaser(baserelease.Basereleaser):
         current = utils.cleanup_version(current)
         suggestion = utils.suggest_version(
             current,
-            breaking=self.data['breaking'],
-            feature=self.data['feature'],
+            breaking=self.data["breaking"],
+            feature=self.data["feature"],
             less_zeroes=self.pypiconfig.less_zeroes(),
             levels=self.pypiconfig.version_levels(),
             dev_marker=self.pypiconfig.development_marker(),
@@ -118,16 +118,18 @@ def main():
         action="store_true",
         dest="feature",
         default=False,
-        help="Bump for feature release (increase minor version)")
+        help="Bump for feature release (increase minor version)",
+    )
     parser.add_argument(
         "--breaking",
         action="store_true",
         dest="breaking",
         default=False,
-        help="Bump for breaking release (increase major version)")
+        help="Bump for breaking release (increase major version)",
+    )
     options = utils.parse_options(parser)
     if options.breaking and options.feature:
-        print('Cannot have both breaking and feature options.')
+        print("Cannot have both breaking and feature options.")
         sys.exit(1)
     utils.configure_logging()
     postreleaser = Postreleaser(breaking=options.breaking, feature=options.feature)

--- a/zest/releaser/tests/postrelease.txt
+++ b/zest/releaser/tests/postrelease.txt
@@ -230,3 +230,75 @@ The old one is left untouched:
     1.0 (1972-12-25)
     <BLANKLINE>
     - hello
+    >>> githead('setup.py')
+    from setuptools import setup, find_packages
+    version = '1.4.dev0'
+
+Let's try some options by simply calling postrelease a few times without calling prerelease or release.
+First prepare a bugfix release.
+
+    >>> utils.test_answer_book.set_answers(['1.5.1', '', 'n'])
+    >>> postrelease.main()
+    Current version is 1.4
+    Question: Enter new development version ('.dev0' will be appended) [1.5]:
+    Our reply: 1.5.1
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    Question: OK to push commits to the server? (Y/n)?
+    Our reply: n
+    >>> githead('setup.py')
+    from setuptools import setup, find_packages
+    version = '1.5.1.dev0'
+
+Now say that the next version should be a feature release:
+
+    >>> utils.test_answer_book.set_answers(['', '', 'n'])
+    >>> import sys
+    >>> sys.argv[1:] = ['--feature']
+    >>> postrelease.main()
+    Current version is 1.5.1
+    Question: Enter new development version ('.dev0' will be appended) [1.6.0]:
+    Our reply: <ENTER>
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    Question: OK to push commits to the server? (Y/n)?
+    Our reply: n
+    >>> githead('setup.py')
+    from setuptools import setup, find_packages
+    version = '1.6.0.dev0'
+
+Now say that the next version should be a breaking release, but make it an alpha:
+
+    >>> utils.test_answer_book.set_answers(['2.0.0a1', '', 'n'])
+    >>> sys.argv[1:] = ['--breaking']
+    >>> postrelease.main()
+    Current version is 1.6.0
+    Question: Enter new development version ('.dev0' will be appended) [2.0.0]:
+    Our reply: 2.0.0a1
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    Question: OK to push commits to the server? (Y/n)?
+    Our reply: n
+    >>> githead('setup.py')
+    from setuptools import setup, find_packages
+    version = '2.0.0a1.dev0'
+
+Now say that the next version is a final release.
+
+    >>> utils.test_answer_book.set_answers(['', '', 'n'])
+    >>> sys.argv[1:] = ['--final']
+    >>> postrelease.main()
+    Current version is 2.0.0a1
+    Question: Enter new development version ('.dev0' will be appended) [2.0.0]:
+    Our reply: <ENTER>
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    Question: OK to push commits to the server? (Y/n)?
+    Our reply: n
+    >>> githead('setup.py')
+    from setuptools import setup, find_packages
+    version = '2.0.0.dev0'


### PR DESCRIPTION
This continues the work by @rnc from PR #393. That PR was waiting for a rebase or merge. And today I added the `--final` option to `bumpversion` so it made sense for me to include it for `postrelease` as well.