### PR TITLE
Support Markdown for History/Changelog

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,22 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
-    - name: Pip cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.*
+          tox.ini
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install tox
+
     - name: Test
       run: tox -e ${{ matrix.config[1] }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         - ["3.11",   "py311"]
         - ["pypy3", "pypy3"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         - ["3.9",   "py39"]
         - ["3.10",   "py310"]
         - ["3.11",   "py311"]
-        - ["pypy3", "pypy3"]
+        - ["pypy3.8", "pypy3"]
 
     runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog for zest.releaser
 7.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Auto-detect ``history_format`` based on history filename.
+  [ericof]
+
+- Add ``history_format`` option, to explicitly set changelogs
+  entries in Markdown.
+  [ericof]
 
 
 7.1.0 (2022-11-23)

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -179,6 +179,9 @@ encoding = a string
   Set this to, for example, ``utf-8`` when the encoding of your ``CHANGES.rst``
   file is not determined correctly.
 
+changelog_format = a string
+  Default: empty.
+  Set this to ``md`` to handle changelog entries in Markdown.
 
 Per project options
 -------------------

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -179,7 +179,7 @@ encoding = a string
   Set this to, for example, ``utf-8`` when the encoding of your ``CHANGES.rst``
   file is not determined correctly.
 
-changelog_format = a string
+history_format = a string
   Default: empty.
   Set this to ``md`` to handle changelog entries in Markdown.
 

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -83,16 +83,16 @@ class Basereleaser:
             utils.AUTO_RESPONSE = True
 
     @property
-    def changelog_format(self):
+    def history_format(self):
         default = "rst"
-        config_value = self.pypiconfig.changelog_format()
+        config_value = self.pypiconfig.history_format()
         history_file = self.data.get("history_file") or ""
         return utils.history_format(config_value, history_file)
 
     @property
     def underline_char(self):
         underline_char = "-"
-        if self.changelog_format == "md":
+        if self.history_format == "md":
             underline_char = ""
         return underline_char
 
@@ -196,7 +196,7 @@ class Basereleaser:
         if self.data["history_file"] is None:
             return
         good_heading = self.data["history_header"] % self.data
-        if self.changelog_format == "md" and not good_heading.startswith("#"):
+        if self.history_format == "md" and not good_heading.startswith("#"):
             good_heading = f"## {good_heading}"
         if not add and self.data.get("has_released_header"):
             # So we are editing a line, but it already has a release date.
@@ -251,7 +251,7 @@ class Basereleaser:
             # edit current line
             history_lines[inject_location] = good_heading
             logger.debug("Set heading from '%s' to '%s'.", previous, good_heading)
-            if self.changelog_format == "rst":
+            if self.history_format == "rst":
                 history_lines[underline_line] = utils.fix_rst_heading(
                     heading=good_heading, below=history_lines[underline_line]
                 )

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -82,6 +82,17 @@ class Basereleaser:
         if self.pypiconfig.no_input():
             utils.AUTO_RESPONSE = True
 
+    @property
+    def changelog_format(self):
+        return self.pypiconfig.changelog_format()
+
+    @property
+    def underline_char(self):
+        underline_char = "-"
+        if self.changelog_format == "md":
+            underline_char = ""
+        return underline_char
+
     def _grab_version(self, initial=False):
         """Just grab the version.
 
@@ -182,6 +193,8 @@ class Basereleaser:
         if self.data["history_file"] is None:
             return
         good_heading = self.data["history_header"] % self.data
+        if self.changelog_format == "md" and not good_heading.startswith("#"):
+            good_heading = f"## {good_heading}"
         if not add and self.data.get("has_released_header"):
             # So we are editing a line, but it already has a release date.
             logger.warning(
@@ -195,14 +208,14 @@ class Basereleaser:
         headings = self.data["headings"]
         history_lines = self.data["history_lines"]
         previous = ""
-        underline_char = "-"
+        underline_char = self.underline_char
         empty = False
         if not history_lines:
             # Remember that we were empty to start with.
             empty = True
             # prepare header line
             history_lines.append("")
-        if len(history_lines) <= 1:
+        if len(history_lines) <= 1 and underline_char:
             # prepare underline
             history_lines.append(underline_char)
         if not headings:
@@ -216,12 +229,13 @@ class Basereleaser:
             underline_char = history_lines[underline_line][0]
         except IndexError:
             logger.debug("No character on line below header.")
-            underline_char = "-"
+            underline_char = self.underline_char
         previous = history_lines[inject_location]
         if add:
+            underline = underline_char * len(good_heading) if underline_char else ""
             inject = [
                 good_heading,
-                underline_char * len(good_heading),
+                underline,
                 "",
                 self.data["nothing_changed_yet"],
                 "",
@@ -234,12 +248,13 @@ class Basereleaser:
             # edit current line
             history_lines[inject_location] = good_heading
             logger.debug("Set heading from '%s' to '%s'.", previous, good_heading)
-            history_lines[underline_line] = utils.fix_rst_heading(
-                heading=good_heading, below=history_lines[underline_line]
-            )
-            logger.debug(
-                "Set line below heading to '%s'", history_lines[underline_line]
-            )
+            if self.changelog_format == "rst":
+                history_lines[underline_line] = utils.fix_rst_heading(
+                    heading=good_heading, below=history_lines[underline_line]
+                )
+                logger.debug(
+                    "Set line below heading to '%s'", history_lines[underline_line]
+                )
         # Setting history_lines is not needed, except when we have replaced the
         # original instead of changing it.  So just set it.
         self.data["history_lines"] = history_lines

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -84,7 +84,10 @@ class Basereleaser:
 
     @property
     def changelog_format(self):
-        return self.pypiconfig.changelog_format()
+        default = "rst"
+        config_value = self.pypiconfig.changelog_format()
+        history_file = self.data.get("history_file") or ""
+        return utils.history_format(config_value, history_file)
 
     @property
     def underline_char(self):

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -392,7 +392,7 @@ class PypiConfig(BaseConfig):
             [zest.releaser]
             changelog_format = md
         """
-        default = "rst"
+        default = ""
         if self.config is None:
             return default
         try:

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -382,6 +382,27 @@ class PypiConfig(BaseConfig):
             return default
         return result
 
+    def changelog_format(self):
+        """Return the format to be used for Changelog files.
+
+        Configure this by adding an ``changelog_format`` option, either in the
+        package you want to release, or in your ~/.pypirc, and using ``rst`` for
+        Restructured Text and ``md`` for Markdown::
+
+            [zest.releaser]
+            changelog_format = md
+        """
+        default = "rst"
+        if self.config is None:
+            return default
+        try:
+            result = self._get_text(
+                "zest.releaser", "changelog_format", default=default, raw=True
+            )
+        except (NoSectionError, NoOptionError, ValueError):
+            return default
+        return result
+
     def create_wheel(self):
         """Should we create a Python wheel for this package?
 

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -382,22 +382,22 @@ class PypiConfig(BaseConfig):
             return default
         return result
 
-    def changelog_format(self):
+    def history_format(self):
         """Return the format to be used for Changelog files.
 
-        Configure this by adding an ``changelog_format`` option, either in the
+        Configure this by adding an ``history_format`` option, either in the
         package you want to release, or in your ~/.pypirc, and using ``rst`` for
         Restructured Text and ``md`` for Markdown::
 
             [zest.releaser]
-            changelog_format = md
+            history_format = md
         """
         default = ""
         if self.config is None:
             return default
         try:
             result = self._get_text(
-                "zest.releaser", "changelog_format", default=default, raw=True
+                "zest.releaser", "history_format", default=default, raw=True
             )
         except (NoSectionError, NoOptionError, ValueError):
             return default

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -152,6 +152,5 @@ history file ends with ``.md``, we consider it Markdown::
     >>> rename_changelog("CHANGES.txt", "CHANGES.md")
     >>> base = baserelease.Basereleaser()
     >>> base._grab_history()
-    >>> breakpoint()
     >>> base.history_format
     'md'

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -142,3 +142,16 @@ And there won't be any underline in headers::
 
     >>> base.underline_char == ""
     True
+
+Also, if we have no ``changelog_format`` setting, but the
+history file ends with ``.md``, we consider it Markdown::
+
+    >>> lines = ["[zest.releaser]", ""]
+    >>> with open('setup.cfg', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+    >>> rename_changelog("CHANGES.txt", "CHANGES.md")
+    >>> base = baserelease.Basereleaser()
+    >>> base._grab_history()
+    >>> breakpoint()
+    >>> base.changelog_format
+    'md'

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -128,14 +128,14 @@ We can use Markdown based on what we find in ``setup.cfg``::
 
     >>> lines = [
     ...     "[zest.releaser]",
-    ...     "changelog_format = md"]
+    ...     "history_format = md"]
     >>> with open('setup.cfg', 'w') as f:
     ...     _ = f.write('\n'.join(lines))
 
 Now, Basereleaser will recognize the format as Markdown::
 
     >>> base = baserelease.Basereleaser()
-    >>> base.changelog_format
+    >>> base.history_format
     'md'
 
 And there won't be any underline in headers::
@@ -143,7 +143,7 @@ And there won't be any underline in headers::
     >>> base.underline_char == ""
     True
 
-Also, if we have no ``changelog_format`` setting, but the
+Also, if we have no ``history_format`` setting, but the
 history file ends with ``.md``, we consider it Markdown::
 
     >>> lines = ["[zest.releaser]", ""]
@@ -153,5 +153,5 @@ history file ends with ``.md``, we consider it Markdown::
     >>> base = baserelease.Basereleaser()
     >>> base._grab_history()
     >>> breakpoint()
-    >>> base.changelog_format
+    >>> base.history_format
     'md'

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -123,3 +123,22 @@ We can prefix and suffix commit messages based on what we find in ``setup.cfg``:
     before Ni!
     <BLANKLINE>
     after
+
+We can use Markdown based on what we find in ``setup.cfg``::
+
+    >>> lines = [
+    ...     "[zest.releaser]",
+    ...     "changelog_format = md"]
+    >>> with open('setup.cfg', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+
+Now, Basereleaser will recognize the format as Markdown::
+
+    >>> base = baserelease.Basereleaser()
+    >>> base.changelog_format
+    'md'
+
+And there won't be any underline in headers::
+
+    >>> base.underline_char == ""
+    True

--- a/zest/releaser/tests/bumpversion.txt
+++ b/zest/releaser/tests/bumpversion.txt
@@ -123,3 +123,33 @@ Now a final release, where we keep the dev marker::
     <BLANKLINE>
     3.0.0 (unreleased)
     ------------------
+
+It will also work if we use Markdown::
+
+    >>> lines = [
+    ...     "[zest.releaser]",
+    ...     "changelog_format = md"]
+    >>> with open('setup.cfg', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+    >>> lines = [
+    ...     "# Changelog",
+    ...     "",
+    ...     "## 3.0.0 (unreleased)"]
+    >>> with open('CHANGES.txt', 'w') as f:
+    ...     _ = f.write('\n'.join(lines))
+    >>> commit_all_changes()
+    >>> utils.test_answer_book.set_answers(['', ''])
+    >>> sys.argv[1:] = ['--final']
+    >>> bumpversion.main()
+    Checking version bump for final release.
+    Last tag: 2.9.4
+    Current version: 3.0.0.dev0
+    Question: Enter version [3.0.1.dev0]:
+    Our reply: <ENTER>
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    >>> githead('CHANGES.txt')
+    # Changelog
+    <BLANKLINE>
+    ## 3.0.1 (unreleased)

--- a/zest/releaser/tests/bumpversion.txt
+++ b/zest/releaser/tests/bumpversion.txt
@@ -128,7 +128,7 @@ It will also work if we use Markdown::
 
     >>> lines = [
     ...     "[zest.releaser]",
-    ...     "changelog_format = md"]
+    ...     "history_format = md"]
     >>> with open('setup.cfg', 'w') as f:
     ...     _ = f.write('\n'.join(lines))
     >>> lines = [

--- a/zest/releaser/tests/functional.py
+++ b/zest/releaser/tests/functional.py
@@ -104,6 +104,10 @@ def setup(test):
             f.write(new_changes)
         commit_all_changes()
 
+    def rename_changelog(src: str, dst: str):
+        execute_command(["git", "mv", src, dst])
+        commit_all_changes()
+
     test.globs.update(
         {
             "tempdir": test.tempdir,
@@ -112,6 +116,7 @@ def setup(test):
             "mock_pypi_available": test.mock_pypi_available,
             "add_changelog_entry": add_changelog_entry,
             "commit_all_changes": commit_all_changes,
+            "rename_changelog": rename_changelog
         }
     )
 

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -953,3 +953,14 @@ def get_list_item(lines):
             count = new_count
     # Return the best one.
     return best
+
+
+def history_format(config_value, history_file):
+    """Decide what is the history/changelog format."""
+    default = "rst"
+    history_format = config_value
+    if not history_format:
+        history_file = history_file or ""
+        ext = history_file.split(".")[-1].lower()
+        history_format = "md" if ext in ["md", "markdown"] else default
+    return history_format


### PR DESCRIPTION
- [X] Add `history_format` option
- [X] Automatically detect history_format based on filename extension
- [X] Update GHA workflow to the latest versions