### PR TITLE
Add option run-pre-commit = yes / no.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,14 @@
 Changelog for zest.releaser
 ===========================
 
-7.2.1 (unreleased)
+7.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add option ``run-pre-commit = yes / no``.
+  Default: no.
+  When set to true, pre commit hooks are run.
+  This may interfere with releasing when they fail.
+  [maurits]
 
 
 7.2.0 (2022-12-09)

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -183,6 +183,13 @@ history_format = a string
   Default: empty.
   Set this to ``md`` to handle changelog entries in Markdown.
 
+run-pre-commit = yes / no
+    Default: no.
+    New in version 7.3.0.
+    When set to true, pre commit hooks are run.
+    This may interfere with releasing when they fail.
+
+
 Per project options
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import codecs
 import sys
 
 
-version = "7.2.1.dev0"
+version = "7.3.0.dev0"
 
 
 def read(filename):

--- a/zest/releaser/git.py
+++ b/zest/releaser/git.py
@@ -67,7 +67,10 @@ class Git(BaseVersionControl):
         return ["git", "diff"]
 
     def cmd_commit(self, message):
-        return ["git", "commit", "-a", "-m", message]
+        parts = ["git", "commit", "-a", "-m", message]
+        if not self.pypi_cfg.run_pre_commit():
+            parts.append("-n")
+        return parts
 
     def cmd_diff_last_commit_against_tag(self, version):
         return ["git", "diff", version]

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -675,3 +675,27 @@ class PypiConfig(BaseConfig):
         except (NoSectionError, NoOptionError, ValueError):
             return default
         return result
+
+    def run_pre_commit(self):
+        """Return whether we should run pre commit hooks.
+
+        At least in git you have pre commit hooks.
+        These may interfere with releasing:
+        zest.releaser changes your setup.py, a pre commit hook
+        runs black or isort and gives an error, so the commit is cancelled.
+        By default (since version 7.3.0) we do not run pre commit hooks.
+
+        Configure it in ~/.pypirc or setup.cfg using a ``tag-signing`` option::
+
+            [zest.releaser]
+            run-pre-commit = yes
+
+        ``run-pre-commit`` must contain exactly one word which will be
+        converted to a boolean. Currently are accepted (case
+        insensitively): 0, false, no, off for False, and 1, true, yes,
+        on for True).
+
+        The default when this option has not been set is False.
+
+        """
+        return self._get_boolean("zest.releaser", "run-pre-commit", default=False)

--- a/zest/releaser/tests/functional.py
+++ b/zest/releaser/tests/functional.py
@@ -78,7 +78,7 @@ def setup(test):
     execute_command(["git", "config", "--local", "commit.gpgsign", "false"])
     execute_command(["git", "config", "--local", "tag.gpgsign", "false"])
     execute_command(["git", "add", "."])
-    execute_command(["git", "commit", "-a", "-m", "init"])
+    execute_command(["git", "commit", "-a", "-m", "init" "-n"])
     os.chdir(test.orig_dir)
 
     def githead(*filename_parts):

--- a/zest/releaser/tests/git.txt
+++ b/zest/releaser/tests/git.txt
@@ -1,4 +1,4 @@
-'Detailed tests of git.py
+Detailed tests of git.py
 ========================
 
 Some initial imports:

--- a/zest/releaser/tests/git.txt
+++ b/zest/releaser/tests/git.txt
@@ -1,4 +1,4 @@
-Detailed tests of git.py
+'Detailed tests of git.py
 ========================
 
 Some initial imports:
@@ -54,7 +54,7 @@ Commit it:
 
     >>> cmd = checkout.cmd_commit('small tweak')
     >>> cmd
-    ['git', 'commit', '-a', '-m', 'small tweak']
+    ['git', 'commit', '-a', '-m', 'small tweak', '-n']
 
 In some cases we get this output:
 ``[master ...] small tweak``

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -58,8 +58,8 @@ class BaseVersionControl:
             # Determine relative path from root of repo.
             self.relative_path_in_repo = os.path.relpath(self.workingdir, reporoot)
         self.setup_cfg = pypi.SetupConfig()
-        pypi_cfg = pypi.PypiConfig()
-        self.fallback_encoding = pypi_cfg.encoding()
+        self.pypi_cfg = pypi.PypiConfig()
+        self.fallback_encoding = self.pypi_cfg.encoding()
 
     def __repr__(self):
         return "<{} at {} {}>".format(


### PR DESCRIPTION
Default: no.
When set to true, pre commit hooks are run.
This may interfere with releasing when they fail.

cc @sneridagh who has hit by this today.