### PR TITLE
Write version in pyproject toml if available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
-        - ["3.6",   "py36"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog for zest.releaser
 7.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support reading and writing the version in ``pyproject.toml``.
+  See `issue 295 <https://github.com/zestsoftware/zest.releaser/issues/295>`_,
+  `issue 373 <https://github.com/zestsoftware/zest.releaser/issues/373>`_,
+  and `PEP-621 <https://peps.python.org/pep-0621/>`_,
+  [maurits]
 
 
 7.3.0 (2023-02-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog for zest.releaser
 7.3.1 (unreleased)
 ------------------
 
+- Drop support for Python 3.6.  [maurits]
+
 - Support reading and writing the version in ``pyproject.toml``.
   See `issue 295 <https://github.com/zestsoftware/zest.releaser/issues/295>`_,
   `issue 373 <https://github.com/zestsoftware/zest.releaser/issues/373>`_,

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Compatibility / Dependencies
 .. image:: https://img.shields.io/pypi/pyversions/zest.releaser?   :alt: PyPI - Python Version
 .. image:: https://img.shields.io/pypi/implementation/zest.releaser?   :alt: PyPI - Implementation
 
-``zest.releaser`` works on Python 3.6+, including PyPy3.
-Tested until Python 3.10, but see ``tox.ini`` for the canonical place for that.
+``zest.releaser`` works on Python 3.7+, including PyPy3.
+Tested until Python 3.11, but see ``tox.ini`` for the canonical place for that.
 
 To be sure: the packages that you release with ``zest.releaser`` may
 very well work on other Python versions: that totally depends on your

--- a/doc/source/developing.rst
+++ b/doc/source/developing.rst
@@ -57,7 +57,7 @@ To run a specific environment and a specific test file::
 Python versions
 ---------------
 
-The tests currently pass on python 3.6-3.10 and PyPy3.
+The tests currently pass on python 3.7-3.11 and PyPy3.
 
 
 Necessary programs

--- a/doc/source/versions.rst
+++ b/doc/source/versions.rst
@@ -4,8 +4,8 @@ Version handling
 Where does the version come from?
 ---------------------------------
 
-A version number is essentially what zest.releaser cannot do without. A
-version number can come from four different locations:
+A version number is essentially what zest.releaser cannot do without.
+A version number can come from various different locations:
 
 - The ``setup.py`` file. Two styles are supported::
 
@@ -20,6 +20,12 @@ version number can come from four different locations:
     def setup(
         version='1.0',
         name='...
+
+- The ``pyproject.toml`` file. zest.releaser will look for something like::
+
+    [project]
+    name = "..."
+    version = "1.0"
 
 - The ``setup.cfg`` file. zest.releaser will look for something like::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+# See https://snarky.ca/what-the-heck-is-pyproject-toml/
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "zest.releaser"
 version = "7.3.1.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "colorama",
     "requests",
     "twine >= 1.6.0",
+    "tomli; python_version<'3.11'",
 ]
 requires-python = ">=3.6"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "twine >= 1.6.0",
     "tomli; python_version<'3.11'",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Developers",
@@ -27,7 +27,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,90 @@
+[project]
+name = "zest.releaser"
+version = "7.3.1.dev0"
+description = "Software releasing made easy and repeatable"
+license = {text = "GPL"}
+authors = [
+    {name = "Reinout van Rees", email = "reinout@vanrees.org"},
+    {name = "Maurits van Rees", email = "maurits@vanrees.org"},
+]
+dependencies = [
+    "setuptools",
+    "colorama",
+    "requests",
+    "twine >= 1.6.0",
+]
+requires-python = ">=3.6"
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU General Public License (GPL)",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["releasing", "packaging", "pypi"]
+# I thought there was a way to combine two files, but I don't see it.
+# So define the readme as dynamic: still defined in setup.py.
+dynamic = ["readme"]
+
+[project.optional-dependencies]
+recommended = [
+    "check-manifest",
+    "pep440",
+    "pyroma",
+    "readme_renderer",
+    "wheel",
+]
+test = [
+    "zope.testing",
+    "zope.testrunner",
+    "wheel",
+]
+
+[project.urls]
+documentation = "https://zestreleaser.readthedocs.io"
+repository = "https://github.com/zestsoftware/zest.releaser/"
+changelog = "https://github.com/zestsoftware/zest.releaser/blob/master/CHANGES.rst"
+
+[project.scripts]
+release = "zest.releaser.release:main"
+prerelease = "zest.releaser.prerelease:main"
+postrelease = "zest.releaser.postrelease:main"
+fullrelease = "zest.releaser.fullrelease:main"
+longtest = "zest.releaser.longtest:main"
+lasttagdiff = "zest.releaser.lasttagdiff:main"
+lasttaglog = "zest.releaser.lasttaglog:main"
+addchangelogentry = "zest.releaser.addchangelogentry:main"
+bumpversion = "zest.releaser.bumpversion:main"
+
+# The datachecks are implemented as entry points to be able to check
+# our entry point implementation.
+[project.entry-points."zest.releaser.prereleaser.middle"]
+datacheck = "zest.releaser.prerelease:datacheck"
+
+[project.entry-points."zest.releaser.releaser.middle"]
+datacheck = "zest.releaser.release:datacheck"
+
+[project.entry-points."zest.releaser.postreleaser.middle"]
+datacheck = "zest.releaser.postrelease:datacheck"
+
+[project.entry-points."zest.releaser.addchangelogentry.middle"]
+datacheck = "zest.releaser.addchangelogentry:datacheck"
+
+[project.entry-points."zest.releaser.bumpversion.middle"]
+datacheck = "zest.releaser.bumpversion:datacheck"
+
+# Documentation generation
+[project.entry-points."zest.releaser.prereleaser.before"]
+preparedocs = "zest.releaser.preparedocs:prepare_entrypoint_documentation"
+
 [tool.isort]
 profile = "plone"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+long_description = file: README.rst, CREDITS.rst, CHANGES.rst
+
 [zest.releaser]
 create-wheel = yes
 extra-message = [ci skip]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if sys.version_info < (3,):
 
 setup(
     long_description=long_description,
-    packages=find_packages(exclude=["ez_setup"]),
+    packages=find_packages(),
     namespace_packages=["zest"],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,8 @@
 from setuptools import find_packages
 from setuptools import setup
 
-import codecs
-import sys
-
-
-def read(filename):
-    try:
-        with codecs.open(filename, encoding="utf-8") as f:
-            return f.read()
-    except NameError:
-        with open(filename, encoding="utf-8") as f:
-            return f.read()
-
-
-long_description = "\n\n".join(
-    [read("README.rst"), read("CREDITS.rst"), read("CHANGES.rst")]
-)
-
-if sys.version_info < (3,):
-    long_description = long_description.encode("utf-8")
-
 
 setup(
-    long_description=long_description,
     packages=find_packages(),
     namespace_packages=["zest"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,6 @@ import codecs
 import sys
 
 
-version = "7.3.1.dev0"
-
-
 def read(filename):
     try:
         with codecs.open(filename, encoding="utf-8") as f:
@@ -26,88 +23,9 @@ if sys.version_info < (3,):
 
 
 setup(
-    name="zest.releaser",
-    version=version,
-    description="Software releasing made easy and repeatable",
     long_description=long_description,
-    classifiers=[
-        "Development Status :: 6 - Mature",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License (GPL)",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    keywords=["releasing", "packaging", "pypi"],
-    author="Reinout van Rees",
-    author_email="reinout@vanrees.org",
-    url="https://zestreleaser.readthedocs.io",
-    license="GPL",
     packages=find_packages(exclude=["ez_setup"]),
     namespace_packages=["zest"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        "setuptools",
-        "colorama",
-        "requests",
-        "twine >= 1.6.0",
-    ],
-    extras_require={
-        "recommended": [
-            "check-manifest",
-            "pep440",
-            "pyroma",
-            "readme_renderer",
-            "wheel",
-        ],
-        "test": [
-            "zope.testing",
-            "zope.testrunner",
-            "wheel",
-        ],
-    },
-    entry_points={
-        "console_scripts": [
-            "release = zest.releaser.release:main",
-            "prerelease = zest.releaser.prerelease:main",
-            "postrelease = zest.releaser.postrelease:main",
-            "fullrelease = zest.releaser.fullrelease:main",
-            "longtest = zest.releaser.longtest:main",
-            "lasttagdiff = zest.releaser.lasttagdiff:main",
-            "lasttaglog = zest.releaser.lasttaglog:main",
-            "addchangelogentry = zest.releaser.addchangelogentry:main",
-            "bumpversion = zest.releaser.bumpversion:main",
-        ],
-        # The datachecks are implemented as entry points to be able to check
-        # our entry point implementation.
-        "zest.releaser.prereleaser.middle": [
-            "datacheck = zest.releaser.prerelease:datacheck",
-        ],
-        "zest.releaser.releaser.middle": [
-            "datacheck = zest.releaser.release:datacheck",
-        ],
-        "zest.releaser.postreleaser.middle": [
-            "datacheck = zest.releaser.postrelease:datacheck",
-        ],
-        "zest.releaser.addchangelogentry.middle": [
-            "datacheck = zest.releaser.addchangelogentry:datacheck",
-        ],
-        "zest.releaser.bumpversion.middle": [
-            "datacheck = zest.releaser.bumpversion:datacheck",
-        ],
-        # Documentation generation
-        "zest.releaser.prereleaser.before": [
-            "preparedocs = "
-            + "zest.releaser.preparedocs:prepare_entrypoint_documentation",
-        ],
-    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36,py37,py38,py39,py310,py311,pypy3
+    py37,py38,py39,py310,py311,pypy3
 
 [testenv]
 usedevelop = true

--- a/zest/releaser/tests/pyproject-toml.txt
+++ b/zest/releaser/tests/pyproject-toml.txt
@@ -1,0 +1,144 @@
+Integration test
+================
+
+Now try a project with only a ``pyproject.toml`` and no ``setup.cfg`` or ``setup.py``.
+
+Several items are prepared for us.
+
+A git directory (repository and checkout in one):
+
+    >>> gitsourcedir
+    'TESTTEMP/tha.example-git'
+    >>> import os
+    >>> os.chdir(gitsourcedir)
+
+We remove and add files.
+
+    >>> from zest.releaser import tests
+    >>> from zest.releaser.utils import execute_command
+    >>> import shutil
+    >>> _ = execute_command(["git", "rm", "setup.cfg", "setup.py"])
+    >>> pyproject_file = os.path.join(os.path.dirname(tests.__file__), "pyproject.toml")
+    >>> shutil.copy(pyproject_file, os.path.curdir)
+    './pyproject.toml'
+    >>> _ = execute_command(["git", "add", "pyproject.toml"])
+    >>> _ = execute_command(["git", "commit", "-m", "Move to pyproject.toml"])
+    >>> print(execute_command(["git", "status"]))
+    On branch master
+    nothing to commit, working directory clean
+
+The version is at 0.1.dev0:
+
+    >>> githead('pyproject.toml')
+    [project]
+    name = "tha.example"
+    version = "0.1.dev0"
+    description = "Example package"
+    keywords = ["example"]
+
+Asking input on the prompt is not unittestable unless we use the prepared
+testing hack in utils.py:
+
+    >>> from zest.releaser import utils
+    >>> utils.TESTMODE = True
+
+Run the prerelease script:
+
+    >>> from zest.releaser import prerelease
+    >>> utils.test_answer_book.set_answers(['', '', '', '', ''])
+    >>> prerelease.main()
+    Question...
+    Question: Enter version [0.1]:
+    Our reply: <ENTER>
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+
+The changelog now has a release date instead of ``(unreleased)``:
+
+    >>> githead('CHANGES.txt')
+    Changelog of tha.example
+    ========================
+    <BLANKLINE>
+    0.1 (2008-12-20)
+    ----------------
+
+And the version number is just 0.1 and has lost its dev marker:
+
+    >>> githead('pyproject.toml')
+    [project]
+    name = "tha.example"
+    version = "0.1"
+    description = "Example package"
+    keywords = ["example"]
+
+The release script tags the release and uploads it.  Note that in the
+other function tests we call
+``mock_pypi_available.append('tha.example')``, but we do not do this
+here.  This way we can check what happens when a package is not yet
+known on PyPI:
+
+    >>> utils.test_answer_book.set_answers(['y', 'y', 'y', 'yes'])
+    >>> from zest.releaser import release
+    >>> release.main()
+    Checking data dict
+    Tag needed to proceed, you can use the following command:
+    git tag 0.1 -m 'Tagging 0.1'
+    Question: Run this command (Y/n)?
+    Our reply: y
+    <BLANKLINE>
+    Question: Check out the tag
+        (for tweaks or pypi/distutils server upload) (y/N)?
+    Our reply: y
+    RED Note: ...0.1...
+    ...
+    RED HEAD is now at ...
+    Preparing release 0.1
+    <BLANKLINE>
+
+TODO No source distribution or wheel is generated yet!!!!!
+This currently only happens when you have a setup.py.
+One related small thing is that for the question "Check out the tag"
+the default answer is No, instead of Yes.
+So there is much more to do.
+But writing pyproject.toml has worked, which is a start.
+
+There is now a tag:
+
+    >>> print(execute_command(["git", "tag"]))
+    0.1
+
+And the postrelease script ups the version:
+
+    >>> utils.test_answer_book.set_answers(['', '', 'n'])
+    >>> from zest.releaser import postrelease
+    >>> postrelease.main()
+    Current version is 0.1
+    Question: Enter new development version ('.dev0' will be appended) [0.2]:
+    Our reply: <ENTER>
+    Checking data dict
+    Question: OK to commit this (Y/n)?
+    Our reply: <ENTER>
+    Question: OK to push commits to the server? (Y/n)?
+    Our reply: n
+
+The changelog and pyproject.toml are at 0.2 and indicate dev mode:
+
+    >>> githead('CHANGES.txt')
+    Changelog of tha.example
+    ========================
+    <BLANKLINE>
+    0.2 (unreleased)
+    ----------------
+    >>> githead('pyproject.toml')
+    [project]
+    name = "tha.example"
+    version = "0.2.dev0"
+    description = "Example package"
+    keywords = ["example"]
+
+And there are no uncommitted changes:
+
+    >>> print(execute_command(["git", "status"]))
+    On branch master
+    nothing to commit, working directory clean

--- a/zest/releaser/tests/pyproject.toml
+++ b/zest/releaser/tests/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "tha.example"
+version = "0.1.dev0"
+description = "Example package"
+keywords = ["example"]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: GNU General Public License (GPL)",
+    "Programming Language :: Python :: 3.9",
+]
+requires-python = ">=3.6"
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- Added `pyproject.toml` and moved most metadata there. "Eat your own dog food." I am not sure if we can get rid of the remaining parts of `setup.py`.
- Add reader. I added `tomli` to the dependencies on Pythons earlier than 3.11. Chances are that you already have this via a different dependency. On 3.11 I use the built-in `tomllib`. 
- Add writer. This is not that different from how we write to `setup.py` or other files.
- Checked that `bin/prerelease` updates the version in our own `pyproject.toml`. I did not commit this.

This fixes issue #373.