### PR TITLE
Do not fail when tag versions cannot be parsed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog for zest.releaser
 8.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Do not fail when tag versions cannot be parsed.
+  This can happen in ``lasttaglog``, ``lasttagdiff``, and ``bumpversion``, with ``setuptools`` 66 or higher.
+  Fixes `issue 408 <https://github.com/zestsoftware/zest.releaser/issues/408>`_.
+  [maurits]
 
 
 8.0.0a1 (2023-02-08)


### PR DESCRIPTION
This can happen in `lasttaglog`, `lasttagdiff`, and `bumpversion`, with `setuptools` 66 or higher. Fixes issue #408.

I see a few test failures locally that should be unrelated.  The tests expect a master branch, but there is a main branch.  This probably differs per git version or local configuration.  Let's see what gh-actions says.