### PR TITLE
Use native namespace packages for zest.releaser.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,13 @@ Changelog for zest.releaser
 9.0.0 (unreleased)
 ------------------
 
-- Use native namespace packages for ``zest.releaser``, instead of deprecated ``pkg_resources`` based ones.
-
 - Changed build system to pypa/build instead of explicitly using
   setuptools.
 
 - Zest.releaser's settings can now also be placed in ``pyproject.toml``.
+
+- Use native namespace packages for ``zest.releaser``, instead of
+  deprecated ``pkg_resources`` based ones.
 
 - Added pre-commit config for neater code (black, flake8, isort).
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog for zest.releaser
 9.0.0 (unreleased)
 ------------------
 
+- Use native namespace packages for ``zest.releaser``, instead of deprecated ``pkg_resources`` based ones.
+
 - Changed build system to pypa/build instead of explicitly using
   setuptools.
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
-from setuptools import find_packages
 from setuptools import setup
 
 
 setup(
-    packages=find_packages(),
-    namespace_packages=["zest"],
+    packages=["zest.releaser"],
     include_package_data=True,
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ deps =
     zest.releaser[test]
     zest.releaser[recommended]
 commands =
-    zope-testrunner --test-path=. --tests-pattern=^tests$ {posargs:-v -c}
+    zope-testrunner --test-path={toxinidir} -s zest.releaser --tests-pattern=^tests$ {posargs:-v -c}

--- a/zest/__init__.py
+++ b/zest/__init__.py
@@ -1,7 +1,0 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-
-    __path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
This is instead of deprecated pkg_resources based ones.

Note that this can be a problem in case `zest.releaser` is installed in combination with other packages in the `zest` namespace. But there are only a few such Plone related packages, so they won't usually be installed in the same virtual environment. And otherwise I can make new releases of those packages. Now seems a good time to do this.

Note that this needed a change in `tox.ini`, otherwise no tests were found.