### PR TITLE
Fix reading of text files when encoding is specified in the config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 9.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- If ``encoding`` is set in the config file, the reading of text doesn't break
+  anymore. Fixes `issue 391
+  <https://github.com/zestsoftware/zest.releaser/issues/391>`_.
 
 
 9.0.0a1 (2023-07-13)

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -779,6 +779,10 @@ We needed to compensate for that so that the following example works:
     True
     >>> encoding
     'utf-8'
+
+Specifying the encoding works, too:
+
+    >>> lines, encoding = utils.read_text_file(example_filename, encoding="utf-8")
     >>> os.remove(example_filename)  # cleanup
 
 By using `.splitlines()`, we reliably handle different lineendings now.

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -73,7 +73,7 @@ def read_text_file(filename, encoding=None, fallback_encoding=None):
         logger.debug(
             "Decoding file %s from encoding %s from argument.", filename, encoding
         )
-        with open(filename, "rb", encoding=encoding) as filehandler:
+        with open(filename, "r", encoding=encoding) as filehandler:
             data = filehandler.read()
         return splitlines_with_trailing(data), encoding
 


### PR DESCRIPTION
On the other hand.... we can take it as a sign that the encoding config option isn't necessary anymore. So we could remove quite some lines of code. (Long live python3 btw!)