### PR TITLE
Ignore error output when calling `build`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for zest.releaser
 9.0.0a2 (unreleased)
 --------------------
 
+- Ignore error output when calling `build`.
+  We only need to look at the exit code to see if it worked.
+
 - Removed ``encoding`` config option as nobody is using it anymore (using the
   option would result in a crash). Apparently it isn't needed anymore now that
   we don't use python 2 anymore. Fixes `issue 391

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog for zest.releaser
 
 - Ignore error output when calling `build`.
   We only need to look at the exit code to see if it worked.
+  You can call zest.releaser with ``--verbose`` if you want 
+  to see the possible warnings.
 
 - Removed ``encoding`` config option as nobody is using it anymore (using the
   option would result in a crash). Apparently it isn't needed anymore now that

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -656,7 +656,7 @@ def _execute_command(command, cwd=None, extra_environ=None):
         show_stderr = False
         # But we really DO want to see the stderr for some other Python commands,
         # otherwise for example a failed upload would not even show up in the output.
-        for flag in ("upload", "register", "build_sdist", "build_wheel", "-mbuild"):
+        for flag in ("upload", "register"):
             if flag in command:
                 show_stderr = True
                 break


### PR DESCRIPTION
We only need to look at the exit code to see if it worked. See https://github.com/zestsoftware/zest.releaser/pull/415#issuecomment-1635596826