### PR TITLE
Check the exit code of a command, instead of relying on stderr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,10 @@ Changelog for zest.releaser
 --------------------
 
 - When a command we call exits with a non-zero exit code, clearly state this in the output.
+  Ask the user if she wants to continue or not.
   Note that this is tricky to do right.  Some commands like ``git`` seem to print everything to stderr,
   leading us to think there are errors, but the exit code is zero, so it should be fine.
-  We do not want to ask the user to often if she wants to continue or not.
-  But we do not want to silently swallow important errors either.
+  We do not want to ask too many questions, but we do not want to silently swallow important errors either.
   [maurits]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog for zest.releaser
 9.0.0a4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- When a command we call exits with a non-zero exit code, clearly state this in the output.
+  Note that this is tricky to do right.  Some commands like ``git`` seem to print everything to stderr,
+  leading us to think there are errors, but the exit code is zero, so it should be fine.
+  We do not want to ask the user to often if she wants to continue or not.
+  But we do not want to silently swallow important errors either.
+  [maurits]
 
 
 9.0.0a3 (2023-07-25)

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -408,6 +408,9 @@ class Basereleaser:
         default_anwer = self.zest_releaser_config.push_changes()
         if utils.ask("OK to push commits to the server?", default=default_anwer):
             for push_cmd in push_cmds:
+                if utils.TESTMODE:
+                    logger.info("MOCK push command: %s", push_cmd)
+                    continue
                 output = execute_command(
                     push_cmd,
                     allow_retry=True,

--- a/zest/releaser/tests/baserelease.txt
+++ b/zest/releaser/tests/baserelease.txt
@@ -155,6 +155,10 @@ history file ends with ``.md``, we consider it Markdown::
     >>> with open('setup.cfg', 'w') as f:
     ...     _ = f.write('\n'.join(lines))
     >>> rename_changelog("CHANGES.txt", "CHANGES.md")
+    >>> with open('setup.py') as f:
+    ...     setup_py_contents = f.read()
+    >>> with open('setup.py', 'w') as f:
+    ...     _ = f.write(setup_py_contents.replace("CHANGES.txt", "CHANGES.md"))
     >>> base = baserelease.Basereleaser()
     >>> base._grab_history()
     >>> base.history_format

--- a/zest/releaser/tests/release.txt
+++ b/zest/releaser/tests/release.txt
@@ -83,12 +83,9 @@ Mock that the tag exists and we get a question:
     Our reply: n
     >>> utils.test_answer_book.set_answers(['y'])
     >>> releaser._info_if_tag_already_exists()
-    Question: There is already a tag 0.1, show if there are differences? (Y/n)?
-    Our reply: y
-    git diff 0.1
-    RED ERROR: exit code 128.
-    RED fatal: ambiguous argument '0.1': unknown revision or path not in the working tree.
-    ...
+    Traceback (most recent call last):
+    ...diff_command...
+    RuntimeError: SYSTEM EXIT (code=1)
 
 Note: the diff itself fails as we mocked its existence.
 

--- a/zest/releaser/tests/release.txt
+++ b/zest/releaser/tests/release.txt
@@ -86,6 +86,7 @@ Mock that the tag exists and we get a question:
     Question: There is already a tag 0.1, show if there are differences? (Y/n)?
     Our reply: y
     git diff 0.1
+    RED ERROR: exit code 128.
     RED fatal: ambiguous argument '0.1': unknown revision or path not in the working tree.
     ...
 

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -489,9 +489,10 @@ We want to discover errors and show them in red.
     '\x1b[31m'
     >>> Fore.MAGENTA
     '\x1b[35m'
-    >>> output = utils.execute_command(['ls', 'some-non-existing-file'])
-    >>> output.startswith(Fore.RED)
-    True
+    >>> utils.execute_command(['ls', 'some-non-existing-file'])
+    Traceback (most recent call last):
+    ...
+    SystemExit: 1
 
 Warnings may also end up in the error output.  That may be unwanted.
 We have a script to test this, which passes all input to std error.

--- a/zest/releaser/tests/utils.txt
+++ b/zest/releaser/tests/utils.txt
@@ -413,8 +413,8 @@ Just one line: no problem:
     >>> utils.show_interesting_lines(output)
     just one line, no newlines
 
-In case of errors, shown in red, we show all and ask what the user
-wants to do.
+In case of errors, shown in red, we show all.
+If there was a non-zero exit code, we ask what the user wants to do.
 
     >>> output = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn"
     >>> utils.show_interesting_lines(output)
@@ -435,11 +435,28 @@ wants to do.
     >>> output = Fore.RED + output
     >>> utils.test_answer_book.set_answers([''])
     >>> utils.show_interesting_lines(output)
+    RED a
+    b
+    c
+    d
+    e
+    f
+    g
+    h
+    i
+    j
+    k
+    l
+    m
+    n
+    >>> output = f"{utils.ERROR_EXIT_CODE} 1\n{output}"
+    >>> utils.show_interesting_lines(output)
     Traceback (most recent call last):
     ...
     SystemExit: 1
     >>> utils.test_answer_book.set_answers(['y'])
     >>> utils.show_interesting_lines(output)
+    ERROR: exit code 1
     RED a
     b
     c


### PR DESCRIPTION
When a command fails, always ask the user to continue or not.  I hope with this we strike a good balance between showing error output, exit codes, and asking if the user wants to continue.

With the previous alpha release, the balance was not good for me.  The final `git push` used `stderr` to report that everything was fine, and then `postrelease` treated this as an error, and asked me if I wanted to continue.  Now we check the exit code.

@elisallenens @gforcada Since Reinout is unavailable for a while, can you review it, or simply try this branch out when releasing some packages?  I could also do another alpha release to more easily try it.