### PR TITLE
Use extras instead of deps in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
 
 [testenv]
 usedevelop = true
-deps =
-    zest.releaser[test]
-    zest.releaser[recommended]
+extras =
+    test
+    recommended
 commands =
     zope-testrunner --test-path={toxinidir} -s zest.releaser --tests-pattern=^tests$ {posargs:-v -c}


### PR DESCRIPTION
The current specification of test dependencies via the `deps` keyword is effectively saying that in addition to both `test` and `recommended` extras there needs to be also `zest.releaser` installed.  This causes inconvenience for downstream packagers because it is creating some sort of circular dependency.

See also: https://peps.python.org/pep-0508/#extras