### PR TITLE
pkgresources fix, but restore Python 3.9 support and fix local errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
+        - ["3.9",   "py39"]
         - ["3.10",   "py310"]
         - ["3.11",   "py311"]
         - ["3.12",   "py312"]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,8 @@ Changelog for zest.releaser
   worked fine, 3.13 needed the pkg_resources fix mentioned above.
   [reinout]
 
-- Dropping support for python 3.8 and 3.9 as the `importlib` we now use is still
-  provisional in 3.8/3.9 and results in some errors.
+- Dropping support for python 3.8 as it is end of life.
+  Also, the `importlib` we now use is still provisional in 3.8 and results in some errors.
   [reinout]
 
 

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Compatibility / Dependencies
 .. image:: https://img.shields.io/pypi/pyversions/zest.releaser?   :alt: PyPI - Python Version
 .. image:: https://img.shields.io/pypi/implementation/zest.releaser?   :alt: PyPI - Implementation
 
-``zest.releaser`` works on Python 3.10+, including PyPy3.  Tested on python
-3.10/11/12/13 and pypy 3.11, but see ``tox.ini`` for the canonical place for that.
+``zest.releaser`` works on Python 3.9+, including PyPy3.  Tested on python
+3.9/3.10/11/12/13 and pypy 3.11, but see ``tox.ini`` for the canonical place for that.
 
 To be sure: the packages that you release with ``zest.releaser`` may
 very well work on other Python versions: that totally depends on your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,14 @@ authors = [
 dependencies = [
     "build >= 1.0.0",  # 1.0.0 changed the API slightly, we support the new syntax
     "colorama",
+    "importlib-metadata; python_version<'3.10'",
     "readme_renderer[md] >= 40",
     "requests",
     "setuptools >= 61.0.0",  # older versions can't read pyproject.toml configurations
     "tomli; python_version<'3.11'",
     "twine >= 1.6.0",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py310,py311,py312,py313,pypy311
+    py39,py310,py311,py312,py313,pypy311
 
 [testenv]
 usedevelop = true

--- a/zest/releaser/baserelease.py
+++ b/zest/releaser/baserelease.py
@@ -73,12 +73,12 @@ class Basereleaser:
         }
         self.setup_cfg = pypi.SetupConfig()
         if utils.TESTMODE:
-            pypirc_old = pkg_resources.resource_filename(
-                "zest.releaser.tests", "pypirc_old.txt"
+            pypirc = pkg_resources.resource_filename(
+                "zest.releaser.tests", "pypirc.txt"
             )
-            self.pypiconfig = pypi.PypiConfig(pypirc_old)
+            self.pypiconfig = pypi.PypiConfig(pypirc)
             self.zest_releaser_config = pypi.ZestReleaserConfig(
-                pypirc_config_filename=pypirc_old
+                pypirc_config_filename=pypirc
             )
         else:
             self.pypiconfig = pypi.PypiConfig()

--- a/zest/releaser/tests/functional-git.txt
+++ b/zest/releaser/tests/functional-git.txt
@@ -100,10 +100,12 @@ known on PyPI:
     creating src/tha.example.egg-info
     ...
     Creating ...
-    removing 'tha_example-0.1' ...
+    removing ...
     Question: Upload to pypi (y/N)?
     Our reply: yes
-    MOCK twine dispatch upload ... dist/tha_example-0.1.tar.gz
+    MOCK twine dispatch upload ...example-0.1.tar.gz
+
+(Note: depending in the Python/setuptools version, the filename may contain ``tha.example`` or ``tha_example``.)
 
 There is now a tag:
 

--- a/zest/releaser/tests/functional-with-hooks.txt
+++ b/zest/releaser/tests/functional-with-hooks.txt
@@ -107,13 +107,14 @@ The release script tags the release and uploads it:
     creating src/tha.example.egg-info
     ...
     Creating ...
-    removing 'tha_example-0.1' ...
+    removing ...
     releaser_before_upload
     Question: Upload to pypi (Y/n)?
     Our reply: y
-    MOCK twine dispatch upload ... dist/tha_example-0.1.tar.gz
+    MOCK twine dispatch upload ...example-0.1.tar.gz
     releaser_after
 
+(Note: depending in the Python/setuptools version, the filename may contain ``tha.example`` or ``tha_example``.)
 
 And the postrelease script ups the version:
 

--- a/zest/releaser/tests/pypirc.txt
+++ b/zest/releaser/tests/pypirc.txt
@@ -1,0 +1,7 @@
+[distutils]
+index-servers =
+    pypi
+
+[pypi]
+username:user
+password:password

--- a/zest/releaser/tests/pyproject-toml.txt
+++ b/zest/releaser/tests/pyproject-toml.txt
@@ -101,10 +101,12 @@ known on PyPI:
     creating src/tha.example.egg-info
     ...
     Creating ...
-    removing 'tha_example-0.1' ...
+    removing ...
     Question: Upload to pypi (y/N)?
     Our reply: yes
-    MOCK twine dispatch upload ... dist/tha_example-0.1.tar.gz
+    MOCK twine dispatch upload ...example-0.1.tar.gz
+
+(Note: depending in the Python/setuptools version, the filename may contain ``tha.example`` or ``tha_example``.)
 
 There is now a tag:
 

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -4,7 +4,6 @@ from argparse import ArgumentParser
 from colorama import Fore
 from packaging.version import parse as parse_version
 
-import importlib
 import logging
 import os
 import re
@@ -20,6 +19,11 @@ logger = logging.getLogger(__name__)
 WRONG_IN_VERSION = ["svn", "dev", "("]
 AUTO_RESPONSE = False
 VERBOSE = False
+
+if sys.version_info.major == 3 and sys.version_info.minor < 10:
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 
 def fs_to_text(fs_name):
@@ -603,7 +607,7 @@ def run_entry_points(which_releaser, when, data):
 
     """
     group = f"zest.releaser.{which_releaser}.{when}"
-    for entrypoint in importlib.metadata.entry_points(group=group):
+    for entrypoint in entry_points(group=group):
         # Grab the function that is the actual plugin.
         plugin = entrypoint.load()
         # Feed the data dict to the plugin.

--- a/zest/releaser/vcs.py
+++ b/zest/releaser/vcs.py
@@ -68,11 +68,11 @@ class BaseVersionControl:
             # Determine relative path from root of repo.
             self.relative_path_in_repo = os.path.relpath(self.workingdir, reporoot)
         if utils.TESTMODE:
-            pypirc_old = pkg_resources.resource_filename(
-                "zest.releaser.tests", "pypirc_old.txt"
+            pypirc = pkg_resources.resource_filename(
+                "zest.releaser.tests", "pypirc.txt"
             )
             self.zest_releaser_config = pypi.ZestReleaserConfig(
-                pypirc_config_filename=pypirc_old
+                pypirc_config_filename=pypirc
             )
         else:
             self.zest_releaser_config = pypi.ZestReleaserConfig()


### PR DESCRIPTION
This builds on PR #456, but restores Python 3.9 support by using `importlib_resources` (only on that version), and fix local errors where I do not understand that they are not going wrong on GitHub Actions.

See [my comment](https://github.com/zestsoftware/zest.releaser/pull/456#pullrequestreview-2654313660) on that PR.