### PR TITLE
Add packaging to our dependencies.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog for zest.releaser
 9.3.1 (unreleased)
 ------------------
 
-- Removed remaining ``pkg_resources`` usage (in the tests).
+- Add ``packaging`` to our dependencies.
+  We were already pulling this in via another dependency.
+  [maurits]
+
+- Removed remaining ``pkg_resources`` usage.
+  [reinout, maurits]
 
 
 9.3.0 (2025-03-03)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "build >= 1.0.0",  # 1.0.0 changed the API slightly, we support the new syntax
     "colorama",
     "importlib-metadata; python_version<'3.10'",
+    "packaging",
     "readme_renderer[md] >= 40",
     "requests",
     "setuptools >= 61.0.0",  # older versions can't read pyproject.toml configurations

--- a/zest/releaser/pypi.py
+++ b/zest/releaser/pypi.py
@@ -2,10 +2,11 @@ from .utils import extract_zestreleaser_configparser
 from configparser import ConfigParser
 from configparser import NoOptionError
 from configparser import NoSectionError
+from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError
 
 import logging
 import os
-import pkg_resources
 import sys
 
 
@@ -17,8 +18,8 @@ except ImportError:
     import tomli as tomllib
 
 try:
-    pkg_resources.get_distribution("wheel")
-except pkg_resources.DistributionNotFound:
+    distribution("wheel")
+except PackageNotFoundError:
     USE_WHEEL = False
 else:
     USE_WHEEL = True

--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -2,6 +2,7 @@
 
 from argparse import ArgumentParser
 from colorama import Fore
+from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 
 import logging
@@ -881,10 +882,7 @@ def get_last_tag(vcs, allow_missing=False):
     for tag in available_tags:
         try:
             parsed_tag = parse_version(tag)
-        except Exception:
-            # I don't want to import this specific exception,
-            # because it sounds unstable:
-            # pkg_resources.extern.packaging.version.InvalidVersion
+        except InvalidVersion:
             logger.debug("Could not parse version: %s", tag)
             continue
         if parsed_tag == parsed_version:


### PR DESCRIPTION
We were already pulling this in via another dependency.

Remove even more remaining `pkg_resources` usage.