### PR TITLE
Require `build` 1.2.0 or higher.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog for zest.releaser
 9.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Require ``build`` 1.2.0 or higher.
+  This added the ``installer`` argument to ``DefaultIsolatedEnv``.
+  [maurits]
 
 
 9.5.0 (2025-03-08)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {name = "Maurits van Rees", email = "maurits@vanrees.org"},
 ]
 dependencies = [
-    "build >= 1.0.0",  # 1.0.0 changed the API slightly, we support the new syntax
+    "build >= 1.2.0",  # 1.2.0 added the 'installer' argument to DefaultIsolatedEnv
     "colorama",
     "importlib-metadata; python_version<'3.10'",
     "packaging",


### PR DESCRIPTION
This added the `installer` argument to `DefaultIsolatedEnv`.

Fixes issue #465.