### PR TITLE
Set long_description_content_type to text/rst.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changelog for zest.releaser
 9.6.2 (2025-04-11)
 ------------------
 
-- Adminstrative change: our pyproject.toml now has the license `in the new SPDX format
+- Administrative change: our ``pyproject.toml`` now has the license `in the new SPDX format
   <https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license>`_.
   [reinout]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 long_description = file: README.rst, CREDITS.rst, CHANGES.rst
+long_description_content_type = text/rst
 
 [check-manifest]
 ignore =


### PR DESCRIPTION
I was just one minute too late with two tiny fixes to your PR. :-)
I rebased and force pushed the same branch.

No release needed for just these changes, but it avoids a `twine check` warning.